### PR TITLE
Generalize HiveExecutor constructor method to accept custom executor …

### DIFF
--- a/go/tasks/v1/qubole/client/qubole_client.go
+++ b/go/tasks/v1/qubole/client/qubole_client.go
@@ -35,10 +35,12 @@ type quboleCmdDetailsInternal struct {
 	Status string
 }
 
+type QuboleUri = string
+
 type QuboleCommandDetails struct {
 	ID     int64
 	Status QuboleStatus
-	JobUri string
+	Uri    QuboleUri
 }
 
 // QuboleClient API Request Body, meant to be passed into JSON.marshal
@@ -196,7 +198,7 @@ func (q *quboleClient) ExecuteHiveCommand(
 	}
 
 	status := NewQuboleStatus(ctx, cmd.Status)
-	return &QuboleCommandDetails{ID: cmd.ID, Status: status, JobUri: fmt.Sprintf(QuboleLogLinkFormat, cmd.ID)}, nil
+	return &QuboleCommandDetails{ID: cmd.ID, Status: status, Uri: fmt.Sprintf(QuboleLogLinkFormat, cmd.ID)}, nil
 }
 
 /*

--- a/go/tasks/v1/qubole/client/qubole_client.go
+++ b/go/tasks/v1/qubole/client/qubole_client.go
@@ -17,7 +17,7 @@ import (
 
 const url = "https://api.qubole.com/api"
 const apiPath = "/v1.2/commands"
-const QuboleLogLinkFormat = "https://api.qubole.com/v2/analyze?command_id=%s"
+const QuboleLogLinkFormat = "https://api.qubole.com/v2/analyze?command_id=%d"
 
 const tokenKeyForAth = "X-AUTH-TOKEN"
 const acceptHeaderKey = "Accept"
@@ -38,6 +38,7 @@ type quboleCmdDetailsInternal struct {
 type QuboleCommandDetails struct {
 	ID     int64
 	Status QuboleStatus
+	JobUri string
 }
 
 // QuboleClient API Request Body, meant to be passed into JSON.marshal
@@ -195,7 +196,7 @@ func (q *quboleClient) ExecuteHiveCommand(
 	}
 
 	status := NewQuboleStatus(ctx, cmd.Status)
-	return &QuboleCommandDetails{ID: cmd.ID, Status: status}, nil
+	return &QuboleCommandDetails{ID: cmd.ID, Status: status, JobUri: fmt.Sprintf(QuboleLogLinkFormat, cmd.ID)}, nil
 }
 
 /*

--- a/go/tasks/v1/qubole/client/qubole_client.go
+++ b/go/tasks/v1/qubole/client/qubole_client.go
@@ -194,7 +194,7 @@ func (q *quboleClient) ExecuteHiveCommand(
 		return nil, err
 	}
 
-	status := newQuboleStatus(ctx, cmd.Status)
+	status := NewQuboleStatus(ctx, cmd.Status)
 	return &QuboleCommandDetails{ID: cmd.ID, Status: status}, nil
 }
 
@@ -242,7 +242,7 @@ func (q *quboleClient) GetCommandStatus(ctx context.Context, commandID string, a
 		return QuboleStatusUnknown, err
 	}
 
-	cmdStatus := newQuboleStatus(ctx, cmd.Status)
+	cmdStatus := NewQuboleStatus(ctx, cmd.Status)
 	return cmdStatus, nil
 }
 

--- a/go/tasks/v1/qubole/client/qubole_status.go
+++ b/go/tasks/v1/qubole/client/qubole_status.go
@@ -28,7 +28,7 @@ var QuboleStatuses = map[QuboleStatus]struct{}{
 	QuboleStatusCancelled: {},
 }
 
-func newQuboleStatus(ctx context.Context, status string) QuboleStatus {
+func NewQuboleStatus(ctx context.Context, status string) QuboleStatus {
 	upperCased := strings.ToUpper(status)
 	if _, ok := QuboleStatuses[QuboleStatus(upperCased)]; ok {
 		return QuboleStatus(upperCased)

--- a/go/tasks/v1/qubole/hive_executor.go
+++ b/go/tasks/v1/qubole/hive_executor.go
@@ -554,13 +554,7 @@ func (h *HiveExecutor) SyncQuboleQuery(ctx context.Context, obj utils2.CacheItem
 }
 
 func NewHiveTaskExecutorWithCache(ctx context.Context) (*HiveExecutor, error) {
-	hiveExecutor := HiveExecutor{
-		id:             hiveExecutorId,
-		secretsManager: NewSecretsManager(),
-		quboleClient:   client.NewQuboleClient(),
-	}
-
-	return &hiveExecutor, nil
+	return NewHiveTaskExecutor(ctx, hiveExecutorId, client.NewQuboleClient())
 }
 
 func NewHiveTaskExecutor(ctx context.Context, executorId string, executorClient client.QuboleClient) (*HiveExecutor, error) {

--- a/go/tasks/v1/qubole/hive_executor.go
+++ b/go/tasks/v1/qubole/hive_executor.go
@@ -562,6 +562,16 @@ func NewHiveTaskExecutorWithCache(ctx context.Context) (*HiveExecutor, error) {
 	return &hiveExecutor, nil
 }
 
+func NewHiveTaskExecutor(ctx context.Context, executorId string, executorClient client.QuboleClient) (*HiveExecutor, error) {
+	hiveExecutor := HiveExecutor{
+		id:             executorId,
+		secretsManager: NewSecretsManager(),
+		quboleClient:   executorClient,
+	}
+
+	return &hiveExecutor, nil
+}
+
 func init() {
 	tasksV1.RegisterLoader(func(ctx context.Context) error {
 		hiveExecutor, err := NewHiveTaskExecutorWithCache(ctx)

--- a/go/tasks/v1/qubole/hive_executor.go
+++ b/go/tasks/v1/qubole/hive_executor.go
@@ -265,7 +265,7 @@ func (h HiveExecutor) CheckTaskStatus(ctx context.Context, taskCtx types.TaskCon
 						commandId := strconv.FormatInt(cmdDetails.ID, 10)
 						logger.Infof(ctx, "Created Qubole ID %s for %s", commandId, workCacheKey)
 						item.CommandId = commandId
-						item.JobUri = cmdDetails.JobUri
+						item.CommandUri = cmdDetails.Uri
 						item.Status = QuboleWorkRunning
 						item.Query = "" // Clear the query to save space in etcd once we've successfully launched
 						err := h.executionBuffer.ConfirmExecution(ctx, workCacheKey, commandId)

--- a/go/tasks/v1/qubole/hive_executor.go
+++ b/go/tasks/v1/qubole/hive_executor.go
@@ -265,6 +265,7 @@ func (h HiveExecutor) CheckTaskStatus(ctx context.Context, taskCtx types.TaskCon
 						commandId := strconv.FormatInt(cmdDetails.ID, 10)
 						logger.Infof(ctx, "Created Qubole ID %s for %s", commandId, workCacheKey)
 						item.CommandId = commandId
+						item.JobUri = cmdDetails.JobUri
 						item.Status = QuboleWorkRunning
 						item.Query = "" // Clear the query to save space in etcd once we've successfully launched
 						err := h.executionBuffer.ConfirmExecution(ctx, workCacheKey, commandId)

--- a/go/tasks/v1/qubole/qubole_work.go
+++ b/go/tasks/v1/qubole/qubole_work.go
@@ -43,6 +43,8 @@ type QuboleWorkItem struct {
 	Query string `json:"query,omitempty"`
 
 	TimeoutSec uint32 `json:"timeout,omitempty"`
+
+	JobUri string `json:"job_uri,omitempty"`
 }
 
 // This ID will be used in a process-wide cache, so it needs to be unique across all concurrent work being done by
@@ -151,7 +153,7 @@ func constructEventInfoFromQuboleWorkItems(taskCtx types.TaskContext, quboleWork
 				Name:          fmt.Sprintf("Retry: %d Status: %s [%s]",
 					taskCtx.GetTaskExecutionID().GetID().RetryAttempt, workItem.Status, workItem.CommandId),
 				MessageFormat: core.TaskLog_UNKNOWN,
-				Uri:           fmt.Sprintf(client.QuboleLogLinkFormat, workItem.CommandId),
+				Uri:           workItem.JobUri,
 			})
 		}
 	}

--- a/go/tasks/v1/qubole/qubole_work.go
+++ b/go/tasks/v1/qubole/qubole_work.go
@@ -1,8 +1,9 @@
 package qubole
 
 import (
-	"fmt"
 	"encoding/json"
+	"fmt"
+
 	"github.com/lyft/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/lyft/flyteplugins/go/tasks/v1/events"
 	"github.com/lyft/flyteplugins/go/tasks/v1/qubole/client"
@@ -44,7 +45,7 @@ type QuboleWorkItem struct {
 
 	TimeoutSec uint32 `json:"timeout,omitempty"`
 
-	JobUri string `json:"job_uri,omitempty"`
+	CommandUri string `json:"command_uri,omitempty"`
 }
 
 // This ID will be used in a process-wide cache, so it needs to be unique across all concurrent work being done by
@@ -150,10 +151,10 @@ func constructEventInfoFromQuboleWorkItems(taskCtx types.TaskContext, quboleWork
 		workItem := v.(QuboleWorkItem)
 		if workItem.CommandId != "" {
 			logs = append(logs, &core.TaskLog{
-				Name:          fmt.Sprintf("Retry: %d Status: %s [%s]",
+				Name: fmt.Sprintf("Retry: %d Status: %s [%s]",
 					taskCtx.GetTaskExecutionID().GetID().RetryAttempt, workItem.Status, workItem.CommandId),
 				MessageFormat: core.TaskLog_UNKNOWN,
-				Uri:           workItem.JobUri,
+				Uri:           workItem.CommandUri,
 			})
 		}
 	}


### PR DESCRIPTION
1. Added a new HiveTaskExecutor constructor to accept custom executor clients
2. Make `NewQuboleStatus` function public 