### PR TITLE
Use jsonpb.Unmarshaler options

### DIFF
--- a/go/tasks/v1/utils/marshal_utils.go
+++ b/go/tasks/v1/utils/marshal_utils.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/golang/protobuf/jsonpb"
 	"github.com/golang/protobuf/proto"
@@ -10,6 +11,9 @@ import (
 )
 
 var jsonPbMarshaler = jsonpb.Marshaler{}
+var jsonPbUnmarshaler = &jsonpb.Unmarshaler{
+	AllowUnknownFields: true,
+}
 
 func UnmarshalStruct(structObj *structpb.Struct, msg proto.Message) error {
 	if structObj == nil {
@@ -21,7 +25,7 @@ func UnmarshalStruct(structObj *structpb.Struct, msg proto.Message) error {
 		return err
 	}
 
-	if err = jsonpb.UnmarshalString(jsonObj, msg); err != nil {
+	if err = jsonPbUnmarshaler.Unmarshal(strings.NewReader(jsonObj), msg); err != nil {
 		return err
 	}
 

--- a/go/tasks/v1/utils/marshal_utils_test.go
+++ b/go/tasks/v1/utils/marshal_utils_test.go
@@ -1,0 +1,28 @@
+package utils
+
+import (
+	structpb "github.com/golang/protobuf/ptypes/struct"
+	"github.com/lyft/flyteidl/gen/pb-go/flyteidl/plugins"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestBackwardsCompatibility(t *testing.T) {
+	sidecarProtoMessage := plugins.SidecarJob{
+		PrimaryContainerName: "primary",
+	}
+
+	sidecarStruct, err := MarshalObjToStruct(sidecarProtoMessage)
+	assert.NoError(t, err)
+
+	// Set a new field in the struct to mimic what happens when we add new fields to protobuf messages
+	sidecarStruct.Fields["hello"] = &structpb.Value{
+		Kind: &structpb.Value_StringValue{
+			StringValue: "world",
+		},
+	}
+
+	newSidecarJob := plugins.SidecarJob{}
+	err = UnmarshalStruct(sidecarStruct, &newSidecarJob)
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
This resolves an issue we were seeing where backwards compatibility of new versions of protobuf messages with new fields were failing.