### PR TITLE
Add validators to where we call unmarshal func

### DIFF
--- a/go/tasks/v1/k8splugins/sidecar.go
+++ b/go/tasks/v1/k8splugins/sidecar.go
@@ -81,14 +81,35 @@ func validateAndFinalizeContainers(
 	return &pod, nil
 }
 
+func validateSidecarJob(sidecarJob *plugins.SidecarJob) error {
+	if sidecarJob == nil {
+		return fmt.Errorf("empty sidecarjob")
+	}
+
+	if sidecarJob.PodSpec == nil {
+		return fmt.Errorf("empty podspec")
+	}
+
+	if len(sidecarJob.PodSpec.Containers) == 0 {
+		return fmt.Errorf("empty containers")
+	}
+
+	return nil
+}
+
 func (sidecarResourceHandler) BuildResource(
 	ctx context.Context, taskCtx types.TaskContext, task *core.TaskTemplate, inputs *core.LiteralMap) (
 	flytek8s.K8sResource, error) {
 	sidecarJob := plugins.SidecarJob{}
 	err := utils.UnmarshalStruct(task.GetCustom(), &sidecarJob)
 	if err != nil {
-		return nil, errors.Errorf(errors.BadTaskSpecification,
-			"invalid TaskSpecification [%v], Err: [%v]", task.GetCustom(), err.Error())
+		return nil, errors.Wrapf(errors.BadTaskSpecification, err,
+			"invalid TaskSpecification [%v], failed to unmarshal", task.GetCustom())
+	}
+
+	if err = validateSidecarJob(&sidecarJob); err != nil {
+		return nil, errors.Wrapf(errors.BadTaskSpecification, err,
+			"invalid TaskSpecification [%v]", task.GetCustom())
 	}
 
 	pod := flytek8s.BuildPodWithSpec(sidecarJob.PodSpec)

--- a/go/tasks/v1/qubole/qubole_work_test.go
+++ b/go/tasks/v1/qubole/qubole_work_test.go
@@ -2,11 +2,12 @@ package qubole
 
 import (
 	"encoding/json"
+	"strings"
+	"testing"
+
 	"github.com/lyft/flyteidl/gen/pb-go/flyteidl/core"
 	tasksMocks "github.com/lyft/flyteplugins/go/tasks/v1/types/mocks"
 	"github.com/stretchr/testify/assert"
-	"strings"
-	"testing"
 )
 
 func getMockTaskContext() *tasksMocks.TaskContext {
@@ -31,6 +32,7 @@ func TestConstructEventInfoFromQuboleWorkItems(t *testing.T) {
 			Status:             QuboleWorkSucceeded,
 			ClusterLabel:       "default",
 			Tags:               []string{},
+			CommandUri:         "https://api.qubole.com/command/",
 		},
 	}
 
@@ -156,12 +158,12 @@ func TestInterfaceConverter(t *testing.T) {
 	// This is a complicated step to reproduce what will ultimately be given to the function at runtime, the values
 	// inside the CustomState
 	item := QuboleWorkItem{
-		Status: QuboleWorkRunning,
-		CommandId: "123456",
-		Query: "",
+		Status:             QuboleWorkRunning,
+		CommandId:          "123456",
+		Query:              "",
 		UniqueWorkCacheKey: "fjdsakfjd",
 	}
-	raw, err := json.Marshal(map[string]interface{}{"":item})
+	raw, err := json.Marshal(map[string]interface{}{"": item})
 	assert.NoError(t, err)
 
 	// We can't unmarshal into a interface{} but we can unmarhsal into a interface{} if it's the value of a map.


### PR DESCRIPTION
This commit  https://github.com/lyft/flyteplugins/commit/99d622cf0f0ca5041e46aad172101536079ea22a relaxed the un-marshaling logic. This PR adds validate* funcs to all places where we unmarshal to ensure the parsed objects are valid.