### PR TITLE
Allow resource deletion when KillTask is called

### DIFF
--- a/go/tasks/v1/flytek8s/mocks/K8sResourceHandler.go
+++ b/go/tasks/v1/flytek8s/mocks/K8sResourceHandler.go
@@ -60,6 +60,20 @@ func (_m *K8sResourceHandler) BuildResource(ctx context.Context, taskCtx types.T
 	return r0, r1
 }
 
+// GetProperties provides a mock function with given fields:
+func (_m *K8sResourceHandler) GetProperties() types.ExecutorProperties {
+	ret := _m.Called()
+
+	var r0 types.ExecutorProperties
+	if rf, ok := ret.Get(0).(func() types.ExecutorProperties); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(types.ExecutorProperties)
+	}
+
+	return r0
+}
+
 // GetTaskStatus provides a mock function with given fields: ctx, taskCtx, resource
 func (_m *K8sResourceHandler) GetTaskStatus(ctx context.Context, taskCtx types.TaskContext, resource flytek8s.K8sResource) (types.TaskStatus, *events.TaskEventInfo, error) {
 	ret := _m.Called(ctx, taskCtx, resource)

--- a/go/tasks/v1/flytek8s/plugin_executor_test.go
+++ b/go/tasks/v1/flytek8s/plugin_executor_test.go
@@ -4,9 +4,10 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	eventErrors "github.com/lyft/flyteidl/clients/go/events/errors"
 	"testing"
 	"time"
+
+	eventErrors "github.com/lyft/flyteidl/clients/go/events/errors"
 
 	k8serrs "k8s.io/apimachinery/pkg/api/errors"
 
@@ -21,7 +22,7 @@ import (
 	"github.com/lyft/flyteplugins/go/tasks/v1/flytek8s/mocks"
 	"github.com/lyft/flytestdlib/storage"
 	"github.com/stretchr/testify/mock"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
@@ -49,6 +50,10 @@ func (k8sSampleHandler) BuildIdentityResource(ctx context.Context, taskCtx types
 }
 
 func (k8sSampleHandler) GetTaskStatus(ctx context.Context, taskCtx types.TaskContext, resource flytek8s.K8sResource) (types.TaskStatus, *events.TaskEventInfo, error) {
+	panic("implement me")
+}
+
+func (k8sSampleHandler) GetProperties() types.ExecutorProperties {
 	panic("implement me")
 }
 
@@ -290,7 +295,6 @@ func TestK8sTaskExecutor_CheckTaskStatus(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, expectedNewStatus, s)
 	})
-
 
 	t.Run("PhaseMismatch", func(t *testing.T) {
 

--- a/go/tasks/v1/flytek8s/plugin_iface.go
+++ b/go/tasks/v1/flytek8s/plugin_iface.go
@@ -29,6 +29,8 @@ type K8sResourceHandler interface {
 
 	// Analyses the k8s resource and reports the status as TaskPhase.
 	GetTaskStatus(ctx context.Context, taskCtx types.TaskContext, resource K8sResource) (types.TaskStatus, *events.TaskEventInfo, error)
+
+	GetProperties() types.ExecutorProperties
 }
 
 type K8sResource interface {

--- a/go/tasks/v1/k8splugins/container.go
+++ b/go/tasks/v1/k8splugins/container.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"github.com/lyft/flyteidl/gen/pb-go/flyteidl/core"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	tasksV1 "github.com/lyft/flyteplugins/go/tasks/v1"
@@ -103,6 +103,10 @@ func (c containerTaskExecutor) BuildResource(ctx context.Context, taskCtx types.
 
 func (containerTaskExecutor) BuildIdentityResource(_ context.Context, taskCtx types.TaskContext) (flytek8s.K8sResource, error) {
 	return flytek8s.BuildIdentityPod(), nil
+}
+
+func (containerTaskExecutor) GetProperties() types.ExecutorProperties {
+	return types.ExecutorProperties{}
 }
 
 func init() {

--- a/go/tasks/v1/k8splugins/sidecar.go
+++ b/go/tasks/v1/k8splugins/sidecar.go
@@ -88,7 +88,7 @@ func (sidecarResourceHandler) BuildResource(
 	err := utils.UnmarshalStruct(task.GetCustom(), &sidecarJob)
 	if err != nil {
 		return nil, errors.Errorf(errors.BadTaskSpecification,
-			"invalid TaskSpecification [%v], Err: [%v]", task.GetCustom(), err.Error())
+		"invalid TaskSpecification [%v], Err: [%v]", task.GetCustom(), err.Error())
 	}
 
 	pod := flytek8s.BuildPodWithSpec(sidecarJob.PodSpec)
@@ -186,6 +186,12 @@ func (sidecarResourceHandler) GetTaskStatus(
 
 	status, err := determinePrimaryContainerStatus(primaryContainerName, pod.Status.ContainerStatuses)
 	return status, info, err
+}
+
+func (sidecarResourceHandler) GetProperties() types.ExecutorProperties {
+	return types.ExecutorProperties{
+		DeleteResourceOnAbort: true,
+	}
 }
 
 func init() {

--- a/go/tasks/v1/k8splugins/spark.go
+++ b/go/tasks/v1/k8splugins/spark.go
@@ -54,6 +54,10 @@ func setSparkConfig(cfg *SparkConfig) error {
 type sparkResourceHandler struct {
 }
 
+func (sparkResourceHandler) GetProperties() types.ExecutorProperties {
+	return types.ExecutorProperties{}
+}
+
 // Creates a new Job that will execute the main container as well as any generated types the result from the execution.
 func (sparkResourceHandler) BuildResource(ctx context.Context, taskCtx types.TaskContext, task *core.TaskTemplate, inputs *core.LiteralMap) (flytek8s.K8sResource, error) {
 
@@ -147,7 +151,7 @@ func (sparkResourceHandler) BuildResource(ctx context.Context, taskCtx types.Tas
 			HadoopConf:     sparkJob.GetHadoopConf(),
 			// SubmissionFailures handled here. Task Failures handled at Propeller/Job level.
 			RestartPolicy: sparkOp.RestartPolicy{
-				Type: sparkOp.OnFailure,
+				Type:                       sparkOp.OnFailure,
 				OnSubmissionFailureRetries: &submissionFailureRetries,
 			},
 		},

--- a/go/tasks/v1/k8splugins/waitable_task.go
+++ b/go/tasks/v1/k8splugins/waitable_task.go
@@ -524,6 +524,10 @@ func (w waitableTaskExecutor) syncItem(ctx context.Context, obj utils2.CacheItem
 	return waitable, utils2.Unchanged, nil
 }
 
+func (waitableTaskExecutor) GetProperties() types.ExecutorProperties {
+	return types.ExecutorProperties{}
+}
+
 func newWaitableTaskExecutor(ctx context.Context) (executor *waitableTaskExecutor, err error) {
 	waitableExec := &waitableTaskExecutor{
 		containerTaskExecutor: containerTaskExecutor{},

--- a/go/tasks/v1/qubole/config/config_flags.go
+++ b/go/tasks/v1/qubole/config/config_flags.go
@@ -45,6 +45,7 @@ func (cfg Config) GetPFlagSet(prefix string) *pflag.FlagSet {
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "resourceManagerType"), defaultConfig.ResourceManagerType, "Which resource manager to use")
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "redisHostPath"), defaultConfig.RedisHostPath, "Redis host location")
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "redisHostKey"), defaultConfig.RedisHostKey, "Key for local Redis access")
+	cmdFlags.Int(fmt.Sprintf("%v%v", prefix, "redisMaxRetries"), defaultConfig.RedisMaxRetries, "See Redis client options for more info")
 	cmdFlags.Int(fmt.Sprintf("%v%v", prefix, "quboleLimit"), defaultConfig.QuboleLimit, "Global limit for concurrent Qubole queries")
 	cmdFlags.Int(fmt.Sprintf("%v%v", prefix, "lruCacheSize"), defaultConfig.LruCacheSize, "Size of the AutoRefreshCache")
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "lookasideBufferPrefix"), defaultConfig.LookasideBufferPrefix, "Prefix used for lookaside buffer")

--- a/go/tasks/v1/qubole/config/config_flags_test.go
+++ b/go/tasks/v1/qubole/config/config_flags_test.go
@@ -187,6 +187,28 @@ func TestConfig_SetFlags(t *testing.T) {
 			}
 		})
 	})
+	t.Run("Test_redisMaxRetries", func(t *testing.T) {
+		t.Run("DefaultValue", func(t *testing.T) {
+			// Test that default value is set properly
+			if vInt, err := cmdFlags.GetInt("redisMaxRetries"); err == nil {
+				assert.Equal(t, int(defaultConfig.RedisMaxRetries), vInt)
+			} else {
+				assert.FailNow(t, err.Error())
+			}
+		})
+
+		t.Run("Override", func(t *testing.T) {
+			testValue := "1"
+
+			cmdFlags.Set("redisMaxRetries", testValue)
+			if vInt, err := cmdFlags.GetInt("redisMaxRetries"); err == nil {
+				testDecodeJson_Config(t, fmt.Sprintf("%v", vInt), &actual.RedisMaxRetries)
+
+			} else {
+				assert.FailNow(t, err.Error())
+			}
+		})
+	})
 	t.Run("Test_quboleLimit", func(t *testing.T) {
 		t.Run("DefaultValue", func(t *testing.T) {
 			// Test that default value is set properly

--- a/go/tasks/v1/types/task.go
+++ b/go/tasks/v1/types/task.go
@@ -31,6 +31,10 @@ type ExecutorProperties struct {
 	// If set, the execution engine will not perform node-level task caching and retrieval. This can be useful for more
 	// fine-grained executors that implement their own logic for caching.
 	DisableNodeLevelCaching bool
+
+	// Determines if resources should be actively deleted when abort is attempted. The default behavior is to clear
+	// finalizers only. If a plugin's resource will automatically be freed by K8s, it should NOT set this field.
+	DeleteResourceOnAbort bool
 }
 
 // Defines the exposed interface for plugins to record task events.


### PR DESCRIPTION
This PR adds a new executorProperty to allow K8s plugins to request deletion of owned resource when KillTask is called