### PR TITLE
Remove Id from Hive execution state

### DIFF
--- a/go/tasks/plugins/hive/execution_state.go
+++ b/go/tasks/plugins/hive/execution_state.go
@@ -289,10 +289,6 @@ func Finalize(ctx context.Context, tCtx core.TaskExecutionContext, _ ExecutionSt
 	return nil
 }
 
-func (e ExecutionStateCacheItem) ID() string {
-	return e.Id
-}
-
 func InTerminalState(e ExecutionState) bool {
 	return e.Phase == PhaseQuerySucceeded || e.Phase == PhaseQueryFailed
 }

--- a/go/tasks/plugins/hive/execution_state_test.go
+++ b/go/tasks/plugins/hive/execution_state_test.go
@@ -56,18 +56,6 @@ func TestIsNotYetSubmitted(t *testing.T) {
 
 }
 
-func TestCopy(t *testing.T) {
-	e0 := ExecutionState{
-		Phase:     PhaseQueryFailed,
-		CommandId: "234",
-	}
-	e1 := Copy(e0)
-	e0.Phase = PhaseQuerySucceeded
-	e0.CommandId = "123"
-	assert.Equal(t, "123", e0.CommandId)
-	assert.Equal(t, "234", e1.CommandId)
-}
-
 func TestGetQueryInfo(t *testing.T) {
 	ctx := context.Background()
 

--- a/go/tasks/plugins/hive/execution_state_test.go
+++ b/go/tasks/plugins/hive/execution_state_test.go
@@ -53,7 +53,6 @@ func TestIsNotYetSubmitted(t *testing.T) {
 			assert.Equal(t, tt.isNotYetSubmitted, res)
 		})
 	}
-
 }
 
 func TestGetQueryInfo(t *testing.T) {
@@ -84,10 +83,9 @@ func TestConstructTaskInfo(t *testing.T) {
 	assert.Nil(t, empty)
 
 	e := ExecutionState{
-		Phase:                 PhaseQuerySucceeded,
-		CommandId:             "123",
-		SyncQuboleApiFailures: 0,
-		Id:                    "some_id",
+		Phase:            PhaseQuerySucceeded,
+		CommandId:        "123",
+		SyncFailureCount: 0,
 	}
 	taskInfo := ConstructTaskInfo(e)
 	assert.Equal(t, "https://api.qubole.com/v2/analyze?command_id=123", taskInfo.Logs[0].Uri)
@@ -96,7 +94,6 @@ func TestConstructTaskInfo(t *testing.T) {
 func TestMapExecutionStateToPhaseInfo(t *testing.T) {
 	t.Run("NotStarted", func(t *testing.T) {
 		e := ExecutionState{
-			Id:    "test",
 			Phase: PhaseNotStarted,
 		}
 		phaseInfo := MapExecutionStateToPhaseInfo(e)
@@ -105,17 +102,15 @@ func TestMapExecutionStateToPhaseInfo(t *testing.T) {
 
 	t.Run("Queued", func(t *testing.T) {
 		e := ExecutionState{
-			Id:                        "test",
-			Phase:                     PhaseQueued,
-			QuboleApiCreationFailures: 0,
+			Phase:                PhaseQueued,
+			CreationFailureCount: 0,
 		}
 		phaseInfo := MapExecutionStateToPhaseInfo(e)
 		assert.Equal(t, core.PhaseQueued, phaseInfo.Phase())
 
 		e = ExecutionState{
-			Id:                        "test",
-			Phase:                     PhaseQueued,
-			QuboleApiCreationFailures: 100,
+			Phase:                PhaseQueued,
+			CreationFailureCount: 100,
 		}
 		phaseInfo = MapExecutionStateToPhaseInfo(e)
 		assert.Equal(t, core.PhaseRetryableFailure, phaseInfo.Phase())
@@ -124,7 +119,6 @@ func TestMapExecutionStateToPhaseInfo(t *testing.T) {
 
 	t.Run("Submitted", func(t *testing.T) {
 		e := ExecutionState{
-			Id:    "test",
 			Phase: PhaseSubmitted,
 		}
 		phaseInfo := MapExecutionStateToPhaseInfo(e)
@@ -209,15 +203,11 @@ func TestFinalize(t *testing.T) {
 	// Test that Finalize releases resources
 	ctx := context.Background()
 	tCtx := GetMockTaskExecutionContext()
-	state := ExecutionState{
-		Id: "fjfklasj",
-	}
+	state := ExecutionState{}
 	var called = false
 	mockResourceManager := tCtx.ResourceManager()
 	x := mockResourceManager.(*mocks.ResourceManager)
-	x.On("ReleaseResource", mock.Anything, mock.Anything, mock.MatchedBy(func(id string) bool {
-		return id == state.Id
-	})).Run(func(_ mock.Arguments) {
+	x.On("ReleaseResource", mock.Anything, mock.Anything, mock.Anything).Run(func(_ mock.Arguments) {
 		called = true
 	}).Return(nil)
 
@@ -230,16 +220,16 @@ func TestMonitorQuery(t *testing.T) {
 	ctx := context.Background()
 	tCtx := GetMockTaskExecutionContext()
 	state := ExecutionState{
-		Id:    "unique-id",
 		Phase: PhaseSubmitted,
 	}
 	var getOrCreateCalled = false
 	mockCache := &stdlibMocks.AutoRefreshCache{}
-	mockCache.On("GetOrCreate", mock.MatchedBy(func(s ExecutionState) bool {
-		return s.Id == state.Id
-	})).Run(func(_ mock.Arguments) {
+	mockCache.On("GetOrCreate", mock.Anything).Run(func(_ mock.Arguments) {
 		getOrCreateCalled = true
-	}).Return(ExecutionState{Id: state.Id, Phase: PhaseQuerySucceeded}, nil)
+	}).Return(ExecutionStateCacheItem{
+		ExecutionState: ExecutionState{Phase: PhaseQuerySucceeded},
+		Id:             "some-id",
+	}, nil)
 
 	newState, err := MonitorQuery(ctx, tCtx, state, mockCache)
 	assert.NoError(t, err)
@@ -269,12 +259,13 @@ func TestKickOffQuery(t *testing.T) {
 	mockCache := &stdlibMocks.AutoRefreshCache{}
 	mockCache.On("GetOrCreate", mock.Anything).Run(func(_ mock.Arguments) {
 		getOrCreateCalled = true
-	}).Return(ExecutionState{}, nil)
+	}).Return(ExecutionStateCacheItem{}, nil)
 
 	state := ExecutionState{}
 	newState, err := KickOffQuery(ctx, tCtx, state, mockQubole, dummySecrets, mockCache)
 	assert.NoError(t, err)
 	assert.Equal(t, PhaseSubmitted, newState.Phase)
+	assert.Equal(t, "453298043", newState.CommandId)
 	assert.True(t, getOrCreateCalled)
 	assert.True(t, quboleCalled)
 }

--- a/go/tasks/plugins/hive/executions_cache.go
+++ b/go/tasks/plugins/hive/executions_cache.go
@@ -50,6 +50,10 @@ type ExecutionStateCacheItem struct {
 	Id string `json:"id"`
 }
 
+func (e ExecutionStateCacheItem) ID() string {
+	return e.Id
+}
+
 // This basically grab an updated status from the Qubole API and store it in the cache
 // All other handling should be in the synchronous loop.
 func (q *QuboleHiveExecutionsCache) SyncQuboleQuery(ctx context.Context, obj utils.CacheItem) (


### PR DESCRIPTION
* Move the Id field out of the plugin state object
* Create a wrapper object encapsulating the plugin state object that adds the Id
* Rename some of the fields to be less qubole.
* Remove the explicit Copy() command since everything is pass by value anyways.

Would like to not merge this until we test again with propeller.