### PR TITLE
qubole validation for older versions of the sdk

### DIFF
--- a/go/tasks/plugins/hive/execution_state.go
+++ b/go/tasks/plugins/hive/execution_state.go
@@ -166,6 +166,14 @@ func GetAllocationToken(ctx context.Context, resourceNamespace core.ResourceName
 	return newState, nil
 }
 
+func validateQuboleHiveJob(hiveJob plugins.QuboleHiveJob) error {
+	if hiveJob.Query == nil {
+		return errors.Errorf(errors.BadTaskSpecification,
+			"Query could not be found. Please ensure that you are at least on Flytekit version 1.21.6 or later.")
+	}
+	return nil
+}
+
 // This function is the link between the output written by the SDK, and the execution side. It extracts the query
 // out of the task template.
 func GetQueryInfo(ctx context.Context, tCtx core.TaskExecutionContext) (
@@ -179,6 +187,10 @@ func GetQueryInfo(ctx context.Context, tCtx core.TaskExecutionContext) (
 	hiveJob := plugins.QuboleHiveJob{}
 	err = utils.UnmarshalStruct(taskTemplate.GetCustom(), &hiveJob)
 	if err != nil {
+		return "", "", []string{}, 0, err
+	}
+
+	if err := validateQuboleHiveJob(hiveJob); err != nil {
 		return "", "", []string{}, 0, err
 	}
 

--- a/go/tasks/plugins/hive/execution_state.go
+++ b/go/tasks/plugins/hive/execution_state.go
@@ -169,7 +169,7 @@ func GetAllocationToken(ctx context.Context, resourceNamespace core.ResourceName
 func validateQuboleHiveJob(hiveJob plugins.QuboleHiveJob) error {
 	if hiveJob.Query == nil {
 		return errors.Errorf(errors.BadTaskSpecification,
-			"Query could not be found. Please ensure that you are at least on Flytekit version 1.21.6 or later.")
+			"Query could not be found. Please ensure that you are at least on Flytekit version 0.3.0 or later.")
 	}
 	return nil
 }

--- a/go/tasks/plugins/hive/execution_state_test.go
+++ b/go/tasks/plugins/hive/execution_state_test.go
@@ -2,6 +2,7 @@ package hive
 
 import (
 	"context"
+	"github.com/lyft/flyteidl/gen/pb-go/flyteidl/plugins"
 	"net/url"
 	"testing"
 
@@ -75,6 +76,16 @@ func TestGetQueryInfo(t *testing.T) {
 	assert.Equal(t, "default", cluster)
 	assert.Equal(t, []string{"flyte_plugin_test"}, tags)
 	assert.Equal(t, 500, int(timeout))
+}
+
+func TestValidateQuboleHiveJob(t *testing.T) {
+	hiveJob := plugins.QuboleHiveJob{
+		ClusterLabel: "default",
+		Tags:         []string{"flyte_plugin_test"},
+		Query:        nil,
+	}
+	err := validateQuboleHiveJob(hiveJob)
+	assert.Error(t, err)
 }
 
 func TestConstructTaskLog(t *testing.T) {


### PR DESCRIPTION
Prior versions of the SDK did not fill in this value.  When this code was written, it was assumed that all prior versions of the SDK would've been deprecated, which was a bad assumption.