### PR TITLE
Hive query tags

### DIFF
--- a/go/tasks/plugins/hive/execution_state.go
+++ b/go/tasks/plugins/hive/execution_state.go
@@ -196,8 +196,12 @@ func GetQueryInfo(ctx context.Context, tCtx core.TaskExecutionContext) (
 
 	query = hiveJob.Query.GetQuery()
 	cluster = hiveJob.ClusterLabel
-	tags = hiveJob.Tags
 	timeoutSec = hiveJob.Query.TimeoutSec
+	tags = hiveJob.Tags
+	tags = append(tags, fmt.Sprintf("ns:%s", tCtx.TaskExecutionMetadata().GetNamespace()))
+	for k, v := range tCtx.TaskExecutionMetadata().GetLabels() {
+		tags = append(tags, fmt.Sprintf("%s:%s", k, v))
+	}
 
 	return
 }

--- a/go/tasks/plugins/hive/execution_state_test.go
+++ b/go/tasks/plugins/hive/execution_state_test.go
@@ -2,9 +2,10 @@ package hive
 
 import (
 	"context"
-	"github.com/lyft/flyteidl/gen/pb-go/flyteidl/plugins"
 	"net/url"
 	"testing"
+
+	"github.com/lyft/flyteidl/gen/pb-go/flyteidl/plugins"
 
 	mocks2 "github.com/lyft/flytestdlib/cache/mocks"
 


### PR DESCRIPTION
Before the plugin api refactor, we used to add these [tags](https://github.com/lyft/flyteplugins/blob/301315810dbc9361567645c6961b97d5c968f2a3/go/tasks/v1/qubole/hive_executor.go#L173-L176) but they were lost in translation.  This adds them back.