### PR TITLE
[MB-1972] Also check failed pod state for OOMKilled

### DIFF
--- a/go/tasks/pluginmachinery/flytek8s/pod_helper.go
+++ b/go/tasks/pluginmachinery/flytek8s/pod_helper.go
@@ -170,13 +170,8 @@ func DemystifyPending(status v1.PodStatus) (pluginsCore.PhaseInfo, error) {
 }
 
 func DemystifySuccess(status v1.PodStatus, info pluginsCore.TaskInfo) (pluginsCore.PhaseInfo, error) {
-	for _, status := range status.ContainerStatuses {
-		if status.State.Terminated != nil && strings.Contains(status.State.Terminated.Reason, OOMKilled) {
-			return pluginsCore.PhaseInfoRetryableFailure("OOMKilled",
-				"Pod reported success despite being OOMKilled", &info), nil
-		}
-	}
-	for _, status := range status.InitContainerStatuses {
+	for _, status := range append(
+		append(status.InitContainerStatuses, status.ContainerStatuses...), status.EphemeralContainerStatuses...) {
 		if status.State.Terminated != nil && strings.Contains(status.State.Terminated.Reason, OOMKilled) {
 			return pluginsCore.PhaseInfoRetryableFailure("OOMKilled",
 				"Pod reported success despite being OOMKilled", &info), nil

--- a/go/tasks/pluginmachinery/flytek8s/pod_helper.go
+++ b/go/tasks/pluginmachinery/flytek8s/pod_helper.go
@@ -189,7 +189,6 @@ func ConvertPodFailureToError(status v1.PodStatus) (code, message string) {
 
 	if len(status.Message) > 0 {
 		message = status.Message
-		return
 	}
 
 	for _, c := range append(

--- a/go/tasks/pluginmachinery/flytek8s/pod_helper.go
+++ b/go/tasks/pluginmachinery/flytek8s/pod_helper.go
@@ -202,6 +202,9 @@ func ConvertPodFailureToError(status v1.PodStatus) (code, message string) {
 					c.LastTerminationState.Terminated.ExitCode,
 					c.LastTerminationState.Terminated.Reason,
 					c.LastTerminationState.Terminated.Message)
+			} else if c.State.Terminated != nil && strings.Contains(c.State.Terminated.Reason, OOMKilled) {
+				code = OOMKilled
+				message += fmt.Sprintf("\r\nInit Container [%v] terminated due to being OOMKilled", c.ContainerID)
 			}
 		}
 
@@ -212,6 +215,9 @@ func ConvertPodFailureToError(status v1.PodStatus) (code, message string) {
 					c.LastTerminationState.Terminated.ExitCode,
 					c.LastTerminationState.Terminated.Reason,
 					c.LastTerminationState.Terminated.Message)
+			} else if c.State.Terminated != nil && strings.Contains(c.State.Terminated.Reason, OOMKilled) {
+				code = OOMKilled
+				message += fmt.Sprintf("\r\nContainer [%v] terminated due to being OOMKilled", c.ContainerID)
 			}
 		}
 
@@ -222,6 +228,9 @@ func ConvertPodFailureToError(status v1.PodStatus) (code, message string) {
 					c.LastTerminationState.Terminated.ExitCode,
 					c.LastTerminationState.Terminated.Reason,
 					c.LastTerminationState.Terminated.Message)
+			} else if c.State.Terminated != nil && strings.Contains(c.State.Terminated.Reason, OOMKilled) {
+				code = OOMKilled
+				message += fmt.Sprintf("\r\nContainer [%v] terminated due to being OOMKilled", c.ContainerID)
 			}
 		}
 	}

--- a/go/tasks/pluginmachinery/flytek8s/pod_helper_test.go
+++ b/go/tasks/pluginmachinery/flytek8s/pod_helper_test.go
@@ -2,10 +2,9 @@ package flytek8s
 
 import (
 	"context"
-	"testing"
-
 	"github.com/lyft/flytestdlib/storage"
 	"github.com/stretchr/testify/mock"
+	"testing"
 
 	"github.com/lyft/flyteplugins/go/tasks/pluginmachinery/flytek8s/config"
 	"github.com/lyft/flyteplugins/go/tasks/pluginmachinery/io"
@@ -389,5 +388,21 @@ func TestConvertPodFailureToError(t *testing.T) {
 	t.Run("known-error", func(t *testing.T) {
 		code, _ := ConvertPodFailureToError(v1.PodStatus{Reason: "hello"})
 		assert.Equal(t, code, "hello")
+	})
+
+	t.Run("OOMKilled", func(t *testing.T) {
+		code, _ := ConvertPodFailureToError(v1.PodStatus{
+			ContainerStatuses: []v1.ContainerStatus{
+				{
+					State: v1.ContainerState{
+						Terminated: &v1.ContainerStateTerminated{
+							Reason:   OOMKilled,
+							ExitCode: 137,
+						},
+					},
+				},
+			},
+		})
+		assert.Equal(t, code, "OOMKilled")
 	})
 }


### PR DESCRIPTION
Example from an OOM-d task:

```containerStatuses:
  - containerID: docker://be556e0d4edeb6435d3f45429334cb8323ea28c3b82de81f44364e2c3de43739
    image: flyteexamples:0510db793bb658155c4175d005b51bf83bdac2f5
    imageID: docker://sha256:0a6270ad43ae5f9d84fbd530206625fdb558529e3a252c118dbfd9226edfd698
    lastState: {}
    name: f0601d8477447476d919-oom-task-0
    ready: false
    restartCount: 0
    state:
      terminated:
        containerID: docker://be556e0d4edeb6435d3f45429334cb8323ea28c3b82de81f44364e2c3de43739
        exitCode: 137
        finishedAt: "2020-02-05T19:50:15Z"
        reason: OOMKilled
        startedAt: "2020-02-05T19:50:13Z"
```