### PR TITLE
Output reader error creation

### DIFF
--- a/go/tasks/pluginmachinery/ioutils/remote_file_output_reader.go
+++ b/go/tasks/pluginmachinery/ioutils/remote_file_output_reader.go
@@ -77,7 +77,7 @@ func (r RemoteFileOutputReader) Exists(ctx context.Context) (bool, error) {
 	}
 	if md.Exists() {
 		if md.Size() > r.maxPayloadSize {
-			return false, errors.Wrapf(err, "error file @[%s] is too large [%d] bytes, max allowed [%d] bytes", r.outPath.GetErrorPath(), md.Size(), r.maxPayloadSize)
+			return false, errors.Errorf("error file @[%s] is too large [%d] bytes, max allowed [%d] bytes", r.outPath.GetErrorPath(), md.Size(), r.maxPayloadSize)
 		}
 		return true, nil
 	}


### PR DESCRIPTION
Wrapf will not create a new error if the err is nil.