### PR TITLE
Abort AWS Batch Job on Finalize

### DIFF
--- a/go/tasks/plugins/array/awsbatch/executor.go
+++ b/go/tasks/plugins/array/awsbatch/executor.go
@@ -118,28 +118,11 @@ func (e Executor) Handle(ctx context.Context, tCtx core.TaskExecutionContext) (c
 }
 
 func (e Executor) Abort(ctx context.Context, tCtx core.TaskExecutionContext) error {
-	pluginState := &State{}
-	if _, err := tCtx.PluginStateReader().Get(pluginState); err != nil {
-		return errors.Wrapf(errors.CorruptedPluginState, err, "Failed to read unmarshal custom state")
-	}
-
-	if pluginState.State == nil {
-		pluginState.State = &arrayCore.State{}
-	}
-
-	p, _ := pluginState.GetPhase()
-	logger.Infof(ctx, "Abort is called with phase [%v]", p)
-
-	switch p {
-	case arrayCore.PhaseCheckingSubTaskExecutions:
-		return TerminateSubTasks(ctx, e.jobStore.Client, *pluginState.GetExternalJobID())
-	}
-
-	return nil
+	return TerminateSubTasks(ctx, tCtx, e.jobStore.Client, "Aborted")
 }
 
 func (e Executor) Finalize(ctx context.Context, tCtx core.TaskExecutionContext) error {
-	return nil
+	return TerminateSubTasks(ctx, tCtx, e.jobStore.Client, "Finalized")
 }
 
 func NewExecutor(ctx context.Context, awsClient aws.Client, cfg *batchConfig.Config,

--- a/go/tasks/plugins/array/awsbatch/launcher.go
+++ b/go/tasks/plugins/array/awsbatch/launcher.go
@@ -69,6 +69,8 @@ func LaunchSubTasks(ctx context.Context, tCtx core.TaskExecutionContext, batchCl
 	return nextState, nil
 }
 
+// Attempts to terminate the AWS Job if one is recorded in the pluginState. This API is idempotent and should be safe
+// to call multiple times on the same job. It'll result in multiple calls to AWS Batch in that case, however.
 func TerminateSubTasks(ctx context.Context, tCtx core.TaskExecutionContext, batchClient Client, reason string) error {
 	pluginState := &State{}
 	if _, err := tCtx.PluginStateReader().Get(pluginState); err != nil {

--- a/go/tasks/plugins/array/awsbatch/launcher.go
+++ b/go/tasks/plugins/array/awsbatch/launcher.go
@@ -74,7 +74,13 @@ func LaunchSubTasks(ctx context.Context, tCtx core.TaskExecutionContext, batchCl
 func TerminateSubTasks(ctx context.Context, tCtx core.TaskExecutionContext, batchClient Client, reason string) error {
 	pluginState := &State{}
 	if _, err := tCtx.PluginStateReader().Get(pluginState); err != nil {
-		return errors.Wrapf(errors.CorruptedPluginState, err, "Failed to read unmarshal custom state")
+		return errors.Wrapf(errors.CorruptedPluginState, err, "Failed to unmarshal custom state")
+	}
+
+	// This only makes sense if the task has "just" been kicked off. Assigning state here is meant to make subsequent
+	// code simpler.
+	if pluginState.State == nil {
+		pluginState.State = &arrayCore.State{}
 	}
 
 	p, _ := pluginState.GetPhase()

--- a/go/tasks/plugins/array/awsbatch/launcher.go
+++ b/go/tasks/plugins/array/awsbatch/launcher.go
@@ -75,10 +75,6 @@ func TerminateSubTasks(ctx context.Context, tCtx core.TaskExecutionContext, batc
 		return errors.Wrapf(errors.CorruptedPluginState, err, "Failed to read unmarshal custom state")
 	}
 
-	if pluginState.State == nil {
-		pluginState.State = &arrayCore.State{}
-	}
-
 	p, _ := pluginState.GetPhase()
 	logger.Infof(ctx, "TerminateSubTasks is called with phase [%v] and reason [%v]", p, reason)
 


### PR DESCRIPTION
AWS Batch Plugin can determine that a task has failed if it detects it can no longer satisfy the failure ratio requirement. When this happens the array task node will be terminated then retried (if there are retry count available). This should trigger a cancellation to the AWS Job as well. 

It was originally written this way to match the old version of this code that, upon discussion, has been deemed a bad design. 

- [X] Need to ensure the cancellation API is idempotent (or add error check/ignore if it's not)
         Validated by running a Workflow and waiting for it to kick off an AWS Job then aborting it. That ended up calling Abort() then Finalize() and the second call was no-op