### PR TITLE
Fix AWS Batch CPU Scale

### DIFF
--- a/go/tasks/plugins/array/awsbatch/transformer.go
+++ b/go/tasks/plugins/array/awsbatch/transformer.go
@@ -168,7 +168,9 @@ func toContainerOverrides(ctx context.Context, command []string, overrides *v1.R
 	envVars []v1.EnvVar) *batch.ContainerOverrides {
 
 	return &batch.ContainerOverrides{
-		Memory:      refInt(overrides.Limits.Memory().ScaledValue(resource.Mega)),
+		// Batch expects memory override in megabytes.
+		Memory: refInt(overrides.Limits.Memory().ScaledValue(resource.Mega)),
+		// Batch expects a rounded number of whole CPUs.
 		Vcpus:       refInt(overrides.Limits.Cpu().Value()),
 		Environment: toEnvironmentVariables(ctx, envVars),
 		Command:     refStrSlice(command),

--- a/go/tasks/plugins/array/awsbatch/transformer.go
+++ b/go/tasks/plugins/array/awsbatch/transformer.go
@@ -169,7 +169,7 @@ func toContainerOverrides(ctx context.Context, command []string, overrides *v1.R
 
 	return &batch.ContainerOverrides{
 		Memory:      refInt(overrides.Limits.Memory().ScaledValue(resource.Mega)),
-		Vcpus:       refInt(overrides.Limits.Cpu().ScaledValue(resource.Mega)),
+		Vcpus:       refInt(overrides.Limits.Cpu().Value()),
 		Environment: toEnvironmentVariables(ctx, envVars),
 		Command:     refStrSlice(command),
 	}

--- a/go/tasks/plugins/array/awsbatch/transformer_test.go
+++ b/go/tasks/plugins/array/awsbatch/transformer_test.go
@@ -6,6 +6,7 @@ package awsbatch
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -62,11 +63,33 @@ func TestResourceRequirementsToBatchRequirements(t *testing.T) {
 	}
 
 	for i, testCase := range memoryTests {
-		q, err := resource.ParseQuantity(testCase.Input)
-		if assert.NoError(t, err) {
-			assert.Equal(t, testCase.Expected, q.ScaledValue(resource.Mega),
-				"Expected != Actual for test case [%v] with Input [%v]", i, testCase.Input)
-		}
+		t.Run(fmt.Sprintf("Memory Test [%v] %v", i, testCase.Input), func(t *testing.T) {
+			q, err := resource.ParseQuantity(testCase.Input)
+			if assert.NoError(t, err) {
+				assert.Equal(t, testCase.Expected, q.ScaledValue(resource.Mega),
+					"Expected != Actual for test case [%v] with Input [%v]", i, testCase.Input)
+			}
+		})
+	}
+
+	cpuTests := []struct {
+		Input    string
+		Expected int64
+	}{
+		// resource Quantity gets the ceiling of values to the nearest scale
+		{"200", 200},
+		{"1M", 1000000},
+		{"15000m", 15},
+	}
+
+	for i, testCase := range cpuTests {
+		t.Run(fmt.Sprintf("CPU Test [%v] %v", i, testCase.Input), func(t *testing.T) {
+			q, err := resource.ParseQuantity(testCase.Input)
+			if assert.NoError(t, err) {
+				assert.Equal(t, testCase.Expected, q.Value(),
+					"Expected != Actual for test case [%v] with Input [%v]", i, testCase.Input)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Use quantity.Value() instead of quantity.ScaledValue() for CPU