### PR TITLE
Replace lower-cased sidecar gpu resource with nvidia one

### DIFF
--- a/go/tasks/pluginmachinery/flytek8s/container_helper.go
+++ b/go/tasks/pluginmachinery/flytek8s/container_helper.go
@@ -19,7 +19,7 @@ import (
 
 var isAcceptableK8sName, _ = regexp.Compile("[a-z0-9]([-a-z0-9]*[a-z0-9])?")
 
-const resourceGPU = "GPU"
+const resourceGPU = "gpu"
 
 // ResourceNvidiaGPU is the name of the Nvidia GPU resource.
 // Copied from: k8s.io/autoscaler/cluster-autoscaler/utils/gpu/gpu.go

--- a/go/tasks/plugins/k8s/sidecar/sidecar_test.go
+++ b/go/tasks/plugins/k8s/sidecar/sidecar_test.go
@@ -156,6 +156,17 @@ func TestBuildSidecarResource(t *testing.T) {
 		primaryContainerKey: "a container",
 	}, res.GetAnnotations())
 	assert.Contains(t, res.(*v1.Pod).Spec.Tolerations, tolGPU)
+
+	// Test GPU overrides
+	expectedGpuRequest := resource.NewQuantity(2, resource.DecimalSI)
+	actualGpuRequest, ok := res.(*v1.Pod).Spec.Containers[0].Resources.Requests[ResourceNvidiaGPU]
+	assert.True(t, ok)
+	assert.True(t, expectedGpuRequest.Equal(actualGpuRequest))
+
+	expectedGpuLimit := resource.NewQuantity(3, resource.DecimalSI)
+	actualGpuLimit, ok := res.(*v1.Pod).Spec.Containers[0].Resources.Limits[ResourceNvidiaGPU]
+	assert.True(t, ok)
+	assert.True(t, expectedGpuLimit.Equal(actualGpuLimit))
 }
 
 func TestBuildSidecarResourceMissingPrimary(t *testing.T) {

--- a/go/tasks/plugins/k8s/sidecar/testdata/sidecar_custom
+++ b/go/tasks/plugins/k8s/sidecar/testdata/sidecar_custom
@@ -27,6 +27,9 @@
 			}],
 			"resources": {
 				"requests": {
+				    "gpu": {
+				    	"string": "2"
+				    },
 					"cpu": {
 						"string": "10"
 					}

--- a/go/tasks/plugins/k8s/sidecar/testdata/sidecar_custom
+++ b/go/tasks/plugins/k8s/sidecar/testdata/sidecar_custom
@@ -36,7 +36,7 @@
 				},
 				"limits": {
 					"nvidia.com/gpu": {
-						"string": "2"
+						"string": "3"
 					},
 					"cpu": {
 						"string": "10"


### PR DESCRIPTION
Addresses https://github.com/lyft/flyte/issues/180 by substituting "gpu" from the sidecar custom resources with the fully nvdia gpu resource name.

When we build Flyte container tasks we never even use "GPU", but rather the full nvidia name (https://github.com/lyft/flytepropeller/blob/f487cfe6e4d35b52f6f9cb399cceb5abf4a0595a/pkg/utils/k8s.go#L58)

I believe only sidecar tasks are (incorrectly) using the "GPU" search string in flyteplugins 