### PR TITLE
Fix Presto status bug that prevents task from moving forward

### DIFF
--- a/go/tasks/plugins/presto/client/noop_presto_client.go
+++ b/go/tasks/plugins/presto/client/noop_presto_client.go
@@ -32,7 +32,7 @@ func (p noopPrestoClient) KillCommand(ctx context.Context, commandID string) err
 }
 
 func (p noopPrestoClient) GetCommandStatus(ctx context.Context, commandID string) (PrestoStatus, error) {
-	return NewPrestoStatus(ctx, "UNKNOWN"), nil
+	return PrestoStatusUnknown, nil
 }
 
 func NewNoopPrestoClient(cfg *config.Config) PrestoClient {

--- a/go/tasks/plugins/presto/client/presto_client.go
+++ b/go/tasks/plugins/presto/client/presto_client.go
@@ -2,8 +2,6 @@ package client
 
 import "context"
 
-type PrestoStatus string
-
 // Contains information needed to execute a Presto query
 type PrestoExecuteArgs struct {
 	RoutingGroup string `json:"routingGroup,omitempty"`
@@ -15,9 +13,8 @@ type PrestoExecuteArgs struct {
 
 // Representation of a response after submitting a query to Presto
 type PrestoExecuteResponse struct {
-	ID      string       `json:"id,omitempty"`
-	Status  PrestoStatus `json:"status,omitempty"`
-	NextURI string       `json:"nextUri,omitempty"`
+	ID      string `json:"id,omitempty"`
+	NextURI string `json:"nextUri,omitempty"`
 }
 
 //go:generate mockery -all -case=snake

--- a/go/tasks/plugins/presto/client/presto_status.go
+++ b/go/tasks/plugins/presto/client/presto_status.go
@@ -1,43 +1,17 @@
 package client
 
-import (
-	"context"
-	"strings"
-
-	"github.com/lyft/flytestdlib/logger"
-)
-
 // This type is meant only to encapsulate the response coming from Presto as a type, it is
 // not meant to be stored locally.
+
+//go:generate enumer --type=PrestoStatus
+
+type PrestoStatus int
+
 const (
-	PrestoStatusUnknown   PrestoStatus = "UNKNOWN"
-	PrestoStatusWaiting   PrestoStatus = "WAITING"
-	PrestoStatusRunning   PrestoStatus = "RUNNING"
-	PrestoStatusFinished  PrestoStatus = "FINISHED"
-	PrestoStatusFailed    PrestoStatus = "FAILED"
-	PrestoStatusCancelled PrestoStatus = "CANCELLED"
+	PrestoStatusUnknown PrestoStatus = iota
+	PrestoStatusWaiting
+	PrestoStatusRunning
+	PrestoStatusFinished
+	PrestoStatusFailed
+	PrestoStatusCancelled
 )
-
-var PrestoStatuses = map[PrestoStatus]struct{}{
-	PrestoStatusUnknown:   {},
-	PrestoStatusWaiting:   {},
-	PrestoStatusRunning:   {},
-	PrestoStatusFinished:  {},
-	PrestoStatusFailed:    {},
-	PrestoStatusCancelled: {},
-}
-
-func NewPrestoStatus(ctx context.Context, state string) PrestoStatus {
-	upperCased := strings.ToUpper(state)
-
-	// Presto has different failure modes so this maps them all to a single Failure on the
-	// Flyte side
-	if strings.Contains(upperCased, "FAILED") {
-		return PrestoStatusFailed
-	} else if _, ok := PrestoStatuses[PrestoStatus(upperCased)]; ok {
-		return PrestoStatus(upperCased)
-	} else {
-		logger.Warnf(ctx, "Invalid Presto Status found: %v", state)
-		return PrestoStatusUnknown
-	}
-}

--- a/go/tasks/plugins/presto/execution_state_test.go
+++ b/go/tasks/plugins/presto/execution_state_test.go
@@ -296,8 +296,7 @@ func TestKickOffQuery(t *testing.T) {
 	var prestoCalled = false
 
 	prestoExecuteResponse := client.PrestoExecuteResponse{
-		ID:     "1234567",
-		Status: client.PrestoStatusWaiting,
+		ID: "1234567",
 	}
 	mockPresto := &prestoMocks.PrestoClient{}
 	mockPresto.OnExecuteCommandMatch(mock.Anything, mock.Anything, mock.Anything, mock.Anything,

--- a/go/tasks/plugins/presto/executions_cache.go
+++ b/go/tasks/plugins/presto/executions_cache.go
@@ -156,6 +156,6 @@ func StatusToExecutionPhase(s client.PrestoStatus) (ExecutionPhase, error) {
 	case client.PrestoStatusUnknown:
 		return PhaseQueryFailed, errors.Errorf(BadPrestoReturnCodeError, "Presto returned status Unknown")
 	default:
-		return PhaseQueryFailed, errors.Errorf(BadPrestoReturnCodeError, "default fallthrough case")
+		return PhaseQueryFailed, errors.Errorf(BadPrestoReturnCodeError, "default fallthrough case: %s", s)
 	}
 }

--- a/go/tasks/plugins/presto/executions_cache.go
+++ b/go/tasks/plugins/presto/executions_cache.go
@@ -118,7 +118,7 @@ func (p *ExecutionsCache) SyncPrestoQuery(ctx context.Context, batch cache.Batch
 			continue
 		}
 
-		newExecutionPhase, err := StatusToExecutionPhase(ctx, commandStatus)
+		newExecutionPhase, err := StatusToExecutionPhase(commandStatus)
 		if err != nil {
 			return nil, err
 		}
@@ -141,7 +141,7 @@ func (p *ExecutionsCache) SyncPrestoQuery(ctx context.Context, batch cache.Batch
 }
 
 // We need some way to translate results we get from Presto, into a plugin phase
-func StatusToExecutionPhase(ctx context.Context, s client.PrestoStatus) (ExecutionPhase, error) {
+func StatusToExecutionPhase(s client.PrestoStatus) (ExecutionPhase, error) {
 	switch s {
 	case client.PrestoStatusFinished:
 		return PhaseQuerySucceeded, nil
@@ -156,7 +156,6 @@ func StatusToExecutionPhase(ctx context.Context, s client.PrestoStatus) (Executi
 	case client.PrestoStatusUnknown:
 		return PhaseQueryFailed, errors.Errorf(BadPrestoReturnCodeError, "Presto returned status Unknown")
 	default:
-		logger.Infof(ctx, "PrestoStatusFinished:  %s, PrestoStatusFinished == s: %s", client.PrestoStatusFinished, client.PrestoStatusFinished == s)
-		return PhaseQueryFailed, errors.Errorf(BadPrestoReturnCodeError, "default fallthrough case: %d", s)
+		return PhaseQueryFailed, errors.Errorf(BadPrestoReturnCodeError, "default fallthrough case")
 	}
 }

--- a/go/tasks/plugins/presto/executions_cache.go
+++ b/go/tasks/plugins/presto/executions_cache.go
@@ -157,6 +157,6 @@ func StatusToExecutionPhase(ctx context.Context, s client.PrestoStatus) (Executi
 		return PhaseQueryFailed, errors.Errorf(BadPrestoReturnCodeError, "Presto returned status Unknown")
 	default:
 		logger.Infof(ctx, "PrestoStatusFinished:  %s, PrestoStatusFinished == s: %s", client.PrestoStatusFinished, client.PrestoStatusFinished == s)
-		return PhaseQueryFailed, errors.Errorf(BadPrestoReturnCodeError, "default fallthrough case: %s", s)
+		return PhaseQueryFailed, errors.Errorf(BadPrestoReturnCodeError, "default fallthrough case: %d", s)
 	}
 }

--- a/go/tasks/plugins/presto/executions_cache.go
+++ b/go/tasks/plugins/presto/executions_cache.go
@@ -118,7 +118,7 @@ func (p *ExecutionsCache) SyncPrestoQuery(ctx context.Context, batch cache.Batch
 			continue
 		}
 
-		newExecutionPhase, err := StatusToExecutionPhase(commandStatus)
+		newExecutionPhase, err := StatusToExecutionPhase(ctx, commandStatus)
 		if err != nil {
 			return nil, err
 		}
@@ -141,7 +141,7 @@ func (p *ExecutionsCache) SyncPrestoQuery(ctx context.Context, batch cache.Batch
 }
 
 // We need some way to translate results we get from Presto, into a plugin phase
-func StatusToExecutionPhase(s client.PrestoStatus) (ExecutionPhase, error) {
+func StatusToExecutionPhase(ctx context.Context, s client.PrestoStatus) (ExecutionPhase, error) {
 	switch s {
 	case client.PrestoStatusFinished:
 		return PhaseQuerySucceeded, nil
@@ -156,6 +156,7 @@ func StatusToExecutionPhase(s client.PrestoStatus) (ExecutionPhase, error) {
 	case client.PrestoStatusUnknown:
 		return PhaseQueryFailed, errors.Errorf(BadPrestoReturnCodeError, "Presto returned status Unknown")
 	default:
+		logger.Infof(ctx, "PrestoStatusFinished:  %s, PrestoStatusFinished == s: %s", client.PrestoStatusFinished, client.PrestoStatusFinished == s)
 		return PhaseQueryFailed, errors.Errorf(BadPrestoReturnCodeError, "default fallthrough case: %s", s)
 	}
 }


### PR DESCRIPTION
# TL;DR
Make it so Presto tasks can proceed

## Type
 - [X] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Before, the value of `PrestoStatus` depended on the Presto client. This, however, could vary based on the client (e.g. Mozart vs raw Presto each had different values for the same status - finished vs done, error vs failure, etc). Because of this, there was an inconsistency when statuses go translated where, for example, the `finished` status from Presto was being compared against the `done` status from Mozart. This inconsistency prevented Presto tasks from moving forward as it was not possible to update the `ExecutionPhase` to the appropriate values.

The bug was fixed by making the `PrestoStatus` always correspond to the same numeric enum, regardless of the client being used. Each client is then responsible for translating their own status to this enum.

## Tracking Issue
https://github.com/lyft/flyte/issues/236
