### PR TITLE
Fix PhaseStatus that gets displayed for Presto tasks

### DIFF
--- a/go/tasks/plugins/presto/execution_state.go
+++ b/go/tasks/plugins/presto/execution_state.go
@@ -56,7 +56,8 @@ func (p ExecutionPhase) String() string {
 }
 
 type ExecutionState struct {
-	Phase ExecutionPhase
+	CurrentPhase  ExecutionPhase
+	PreviousPhase ExecutionPhase
 
 	// This will store the command ID from Presto
 	CommandID string `json:"commandId,omitempty"`
@@ -105,7 +106,7 @@ func HandleExecutionState(
 	var transformError error
 	var newState ExecutionState
 
-	switch currentState.Phase {
+	switch currentState.CurrentPhase {
 	case PhaseNotStarted:
 		newState, transformError = GetAllocationToken(ctx, tCtx, currentState, metrics)
 
@@ -125,8 +126,11 @@ func HandleExecutionState(
 			// If there are still Presto statements to execute, increment the query count, reset the phase to 'queued'
 			// and continue executing the remaining statements. In this case, we won't request another allocation token
 			// as the 5 statements that get executed are all considered to be part of the same "query"
-			currentState.Phase = PhaseQueued
+			currentState.PreviousPhase = currentState.CurrentPhase
+			currentState.CurrentPhase = PhaseQueued
 		} else {
+			//currentState.Phase = PhaseQuerySucceeded
+			currentState.PreviousPhase = currentState.CurrentPhase
 			transformError = writeOutput(ctx, tCtx, currentState.CurrentPrestoQuery.ExternalLocation)
 		}
 		currentState.QueryCount++
@@ -172,11 +176,11 @@ func GetAllocationToken(
 	}
 
 	if allocationStatus == core.AllocationStatusGranted {
-		newState.Phase = PhaseQueued
+		newState.CurrentPhase = PhaseQueued
 	} else if allocationStatus == core.AllocationStatusExhausted {
-		newState.Phase = PhaseNotStarted
+		newState.CurrentPhase = PhaseNotStarted
 	} else if allocationStatus == core.AllocationStatusNamespaceQuotaExceeded {
-		newState.Phase = PhaseNotStarted
+		newState.CurrentPhase = PhaseNotStarted
 	} else {
 		return newState, errors.Errorf(errors.ResourceManagerFailure, "Got bad allocation result [%s] for token [%s]",
 			allocationStatus, uniqueID)
@@ -389,7 +393,8 @@ func KickOffQuery(
 		commandID := response.ID
 		logger.Infof(ctx, "Created Presto ID [%s] for token %s", commandID, uniqueID)
 		currentState.CommandID = commandID
-		currentState.Phase = PhaseSubmitted
+		currentState.PreviousPhase = currentState.CurrentPhase
+		currentState.CurrentPhase = PhaseSubmitted
 		currentState.URI = response.NextURI
 		currentState.CurrentPrestoQueryUUID = uniqueID
 
@@ -475,7 +480,8 @@ func MapExecutionStateToPhaseInfo(state ExecutionState) core.PhaseInfo {
 	var phaseInfo core.PhaseInfo
 	t := time.Now()
 
-	switch state.Phase {
+	//switch state.Phase {
+	switch state.CurrentPhase {
 	case PhaseNotStarted:
 		phaseInfo = core.PhaseInfoNotReady(t, core.DefaultPhaseVersion, "Haven't received allocation token")
 	case PhaseQueued:
@@ -515,7 +521,7 @@ func ConstructTaskInfo(e ExecutionState) *core.TaskInfo {
 
 func ConstructTaskLog(e ExecutionState) *idlCore.TaskLog {
 	return &idlCore.TaskLog{
-		Name:          fmt.Sprintf("Status: %s [%s]", e.Phase, e.CommandID),
+		Name:          fmt.Sprintf("Status: %s [%s]", e.PreviousPhase, e.CommandID),
 		MessageFormat: idlCore.TaskLog_UNKNOWN,
 		Uri:           e.URI,
 	}
@@ -551,11 +557,11 @@ func Finalize(ctx context.Context, tCtx core.TaskExecutionContext, _ ExecutionSt
 }
 
 func InTerminalState(e ExecutionState) bool {
-	return e.Phase == PhaseQuerySucceeded || e.Phase == PhaseQueryFailed
+	return e.CurrentPhase == PhaseQuerySucceeded || e.CurrentPhase == PhaseQueryFailed
 }
 
 func IsNotYetSubmitted(e ExecutionState) bool {
-	if e.Phase == PhaseNotStarted || e.Phase == PhaseQueued {
+	if e.CurrentPhase == PhaseNotStarted || e.CurrentPhase == PhaseQueued {
 		return true
 	}
 	return false

--- a/go/tasks/plugins/presto/executions_cache.go
+++ b/go/tasks/plugins/presto/executions_cache.go
@@ -123,11 +123,12 @@ func (p *ExecutionsCache) SyncPrestoQuery(ctx context.Context, batch cache.Batch
 			return nil, err
 		}
 
-		if newExecutionPhase > executionStateCacheItem.Phase {
+		if newExecutionPhase > executionStateCacheItem.CurrentPhase {
 			logger.Infof(ctx, "Moving ExecutionPhase for %s %s from %s to %s", executionStateCacheItem.CommandID,
-				executionStateCacheItem.Identifier, executionStateCacheItem.Phase, newExecutionPhase)
+				executionStateCacheItem.Identifier, executionStateCacheItem.CurrentPhase, newExecutionPhase)
 
-			executionStateCacheItem.Phase = newExecutionPhase
+			executionStateCacheItem.PreviousPhase = executionStateCacheItem.CurrentPhase
+			executionStateCacheItem.CurrentPhase = newExecutionPhase
 
 			resp = append(resp, cache.ItemSyncResponse{
 				ID:     query.GetID(),

--- a/go/tasks/plugins/presto/executions_cache_test.go
+++ b/go/tasks/plugins/presto/executions_cache_test.go
@@ -34,7 +34,7 @@ func TestPrestoExecutionsCache_SyncQuboleQuery(t *testing.T) {
 		}
 
 		state := ExecutionState{
-			Phase: PhaseQuerySucceeded,
+			CurrentPhase: PhaseQuerySucceeded,
 		}
 		cacheItem := ExecutionStateCacheItem{
 			ExecutionState: state,
@@ -67,8 +67,8 @@ func TestPrestoExecutionsCache_SyncQuboleQuery(t *testing.T) {
 		}
 
 		state := ExecutionState{
-			CommandID: "123456",
-			Phase:     PhaseSubmitted,
+			CommandID:    "123456",
+			CurrentPhase: PhaseSubmitted,
 		}
 		cacheItem := ExecutionStateCacheItem{
 			ExecutionState: state,
@@ -86,6 +86,6 @@ func TestPrestoExecutionsCache_SyncQuboleQuery(t *testing.T) {
 		newExecutionState := newCacheItem[0].Item.(ExecutionStateCacheItem)
 		assert.NoError(t, err)
 		assert.Equal(t, cache.Update, newCacheItem[0].Action)
-		assert.Equal(t, PhaseQuerySucceeded, newExecutionState.Phase)
+		assert.Equal(t, PhaseQuerySucceeded, newExecutionState.CurrentPhase)
 	})
 }


### PR DESCRIPTION
# TL;DR
When running a Presto task, the status of each of the 5 queries is not displayed properly.
<img width="1646" alt="Screen Shot 2020-04-02 at 2 04 27 PM" src="https://user-images.githubusercontent.com/3936213/78299577-077d2500-74eb-11ea-8771-64788a82f91a.png">

## Type
 - [X] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [X] Code completed
 - [ ] Smoke tested
 - [X] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Due to how the state machine the Presto plugin uses goes back and forth between various states, I keep track of the of both the current and previous states and use the previous state for the status that gets displayed to users.

## Tracking Issue
https://github.com/lyft/flyte/issues/237
