### PR TITLE
Permanent Failures classification

### DIFF
--- a/go/tasks/pluginmachinery/core/phase.go
+++ b/go/tasks/pluginmachinery/core/phase.go
@@ -180,8 +180,12 @@ func PhaseInfoSuccess(info *TaskInfo) PhaseInfo {
 	return phaseInfo(PhaseSuccess, DefaultPhaseVersion, nil, info)
 }
 
+func PhaseInfoSystemFailure(code, reason string, info *TaskInfo) PhaseInfo {
+	return PhaseInfoFailed(PhasePermanentFailure, &core.ExecutionError{Code: code, Message: reason, Kind: core.ExecutionError_SYSTEM}, info)
+}
+
 func PhaseInfoFailure(code, reason string, info *TaskInfo) PhaseInfo {
-	return PhaseInfoFailed(PhasePermanentFailure, &core.ExecutionError{Code: code, Message: reason}, info)
+	return PhaseInfoFailed(PhasePermanentFailure, &core.ExecutionError{Code: code, Message: reason, Kind: core.ExecutionError_USER}, info)
 }
 
 func PhaseInfoRetryableFailure(code, reason string, info *TaskInfo) PhaseInfo {

--- a/go/tasks/pluginmachinery/flytek8s/pod_helper.go
+++ b/go/tasks/pluginmachinery/flytek8s/pod_helper.go
@@ -163,8 +163,10 @@ func DemystifyPending(status v1.PodStatus) (pluginsCore.PhaseInfo, error) {
 								}), nil
 
 							case "ImagePullBackOff":
-								// TODO once we implement timeouts, this should probably be PhaseInitializing with version 1, so that user can see the reason
-								fallthrough
+								t := c.LastTransitionTime.Time
+								return pluginsCore.PhaseInfoRetryableFailure(finalReason, finalMessage, &pluginsCore.TaskInfo{
+									OccurredAt: &t,
+								}), nil
 							default:
 								// Since we are not checking for all error states, we may end up perpetually
 								// in the queued state returned at the bottom of this function, until the Pod is reaped
@@ -173,8 +175,8 @@ func DemystifyPending(status v1.PodStatus) (pluginsCore.PhaseInfo, error) {
 								// reasons, then we will assume a failure reason, and fail instantly
 								t := c.LastTransitionTime.Time
 								return pluginsCore.PhaseInfoSystemRetryableFailure(finalReason, finalMessage, &pluginsCore.TaskInfo{
-									OccurredAt: &t,
-								}), nil
+								OccurredAt: &t,
+							}), nil
 							}
 
 						}

--- a/go/tasks/pluginmachinery/flytek8s/pod_helper.go
+++ b/go/tasks/pluginmachinery/flytek8s/pod_helper.go
@@ -175,8 +175,8 @@ func DemystifyPending(status v1.PodStatus) (pluginsCore.PhaseInfo, error) {
 								// reasons, then we will assume a failure reason, and fail instantly
 								t := c.LastTransitionTime.Time
 								return pluginsCore.PhaseInfoSystemRetryableFailure(finalReason, finalMessage, &pluginsCore.TaskInfo{
-								OccurredAt: &t,
-							}), nil
+									OccurredAt: &t,
+								}), nil
 							}
 
 						}

--- a/go/tasks/plugins/array/core/state.go
+++ b/go/tasks/plugins/array/core/state.go
@@ -212,7 +212,7 @@ func MapArrayStateToPluginPhase(_ context.Context, state *State, logLinks []*idl
 		if state.GetExecutionErr() != nil {
 			phaseInfo = core.PhaseInfoFailed(core.PhasePermanentFailure, state.GetExecutionErr(), nowTaskInfo)
 		} else {
-			phaseInfo = core.PhaseInfoFailure(ErrorK8sArrayGeneric, state.GetReason(), nowTaskInfo)
+			phaseInfo = core.PhaseInfoSystemFailure(ErrorK8sArrayGeneric, state.GetReason(), nowTaskInfo)
 		}
 	default:
 		return phaseInfo, fmt.Errorf("failed to map custom state phase to core phase. State Phase [%v]", p)

--- a/go/tasks/plugins/k8s/sidecar/sidecar.go
+++ b/go/tasks/plugins/k8s/sidecar/sidecar.go
@@ -127,7 +127,6 @@ func determinePrimaryContainerPhase(primaryContainerName string, statuses []k8sv
 	}
 
 	// If for some reason we can't find the primary container, always just return a permanent failure
-
 	return pluginsCore.PhaseInfoFailure("PrimaryContainerMissing",
 		fmt.Sprintf("Primary container [%s] not found in pod's container statuses", primaryContainerName), info)
 }


### PR DESCRIPTION
# TL;DR
 - ImagePullBackoff should be a user error
 - Added a method to delineate system and user perm errors

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [x] Code documentation added
 - [x] Any pending items have an associated Issue

## Complete description
User and system error should be differentiated even for permanent errors case.

## Tracking Issue
https://github.com/lyft/flyte/issues/300

## Follow-up issue
NA
