### PR TITLE
Populate ExecutionError Kind from Container Errors

### DIFF
--- a/go/tasks/pluginmachinery/ioutils/remote_file_output_reader.go
+++ b/go/tasks/pluginmachinery/ioutils/remote_file_output_reader.go
@@ -42,6 +42,7 @@ func (r RemoteFileOutputReader) ReadError(ctx context.Context) (io.ExecutionErro
 				ExecutionError: &core.ExecutionError{
 					Code:    "ErrorFileNotFound",
 					Message: err.Error(),
+					Kind:    core.ExecutionError_SYSTEM,
 				},
 			}, nil
 		}
@@ -54,6 +55,7 @@ func (r RemoteFileOutputReader) ReadError(ctx context.Context) (io.ExecutionErro
 			ExecutionError: &core.ExecutionError{
 				Code:    "ErrorFileBadFormat",
 				Message: fmt.Sprintf("error not formatted correctly, nil error @path [%s]", r.outPath.GetErrorPath()),
+				Kind:    core.ExecutionError_SYSTEM,
 			},
 		}, nil
 	}
@@ -62,11 +64,14 @@ func (r RemoteFileOutputReader) ReadError(ctx context.Context) (io.ExecutionErro
 		ExecutionError: &core.ExecutionError{
 			Code:    errorDoc.Error.Code,
 			Message: errorDoc.Error.Message,
+			Kind:    core.ExecutionError_USER, // TODO: read it from container error once populated by SDK
 		},
 	}
+
 	if errorDoc.Error.Kind == core.ContainerError_RECOVERABLE {
 		ee.IsRecoverable = true
 	}
+
 	return ee, nil
 }
 


### PR DESCRIPTION
# TL;DR
FlyteKit populates a Container Error message that the plugin machinery then transforms into ExecutionError. In the process, we do not populate the execution error kind leading to tasks always getting tagged with Unknown Kind

## Type
 - [X] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [X] Code completed
 - [X] Smoke tested
 - [X] Unit tests added
 - [X] Code documentation added
 - [X] Any pending items have an associated Issue

## Tracking Issue
https://github.com/lyft/flyte/issues/300
