### PR TITLE
Read the stderr into termination reason when container fails

### DIFF
--- a/go/tasks/pluginmachinery/flytek8s/container_helper.go
+++ b/go/tasks/pluginmachinery/flytek8s/container_helper.go
@@ -118,11 +118,12 @@ func ToK8sContainer(ctx context.Context, taskExecutionMetadata pluginsCore.TaskE
 		containerName = rand.String(4)
 	}
 	c := &v1.Container{
-		Name:    containerName,
-		Image:   taskContainer.GetImage(),
-		Args:    modifiedArgs,
-		Command: modifiedCommand,
-		Env:     envVars,
+		Name:                     containerName,
+		Image:                    taskContainer.GetImage(),
+		Args:                     modifiedArgs,
+		Command:                  modifiedCommand,
+		Env:                      envVars,
+		TerminationMessagePolicy: v1.TerminationMessageFallbackToLogsOnError,
 	}
 
 	if res != nil {


### PR DESCRIPTION
# TL;DR
This change will automatically read the pod log and set it as the termination reason when the container exits with non-zero exit code. In case of flytekit, and it fails to write error.pb, the log will have more information to surface to users.

## Type
 - [ ] Bug Fix
 - [X] Feature
 - [ ] Plugin

## Are all requirements met?

 - [X] Code completed
 - [X] Smoke tested
 - [X] Unit tests added
 - [X] Code documentation added
 - [X] Any pending items have an associated Issue

## Tracking Issue
https://github.com/lyft/flyte/issues/308
