### PR TITLE
Fix flag name

### DIFF
--- a/go/tasks/plugins/hive/config/config.go
+++ b/go/tasks/plugins/hive/config/config.go
@@ -63,7 +63,7 @@ type Config struct {
 	TokenKey                  string                     `json:"quboleTokenKey" pflag:",Name of the key where to find Qubole token in the secret manager."`
 	LruCacheSize              int                        `json:"lruCacheSize" pflag:",Size of the AutoRefreshCache"`
 	Workers                   int                        `json:"workers" pflag:",Number of parallel workers to refresh the cache"`
-	DefaultClusterLabel       string                     `json:"defaultClusterConfig" pflag:",The default cluster label. This will be used if label is not specified on the hive job."`
+	DefaultClusterLabel       string                     `json:"defaultClusterLabel" pflag:",The default cluster label. This will be used if label is not specified on the hive job."`
 	ClusterConfigs            []ClusterConfig            `json:"clusterConfigs" pflag:"-,A list of cluster configs. Each of the configs corresponds to a service cluster"`
 	DestinationClusterConfigs []DestinationClusterConfig `json:"destinationClusterConfigs" pflag:"-,A list configs specifying the destination service cluster for (project, domain)"`
 }

--- a/go/tasks/plugins/hive/config/config_flags.go
+++ b/go/tasks/plugins/hive/config/config_flags.go
@@ -47,5 +47,6 @@ func (cfg Config) GetPFlagSet(prefix string) *pflag.FlagSet {
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "quboleTokenKey"), defaultConfig.TokenKey, "Name of the key where to find Qubole token in the secret manager.")
 	cmdFlags.Int(fmt.Sprintf("%v%v", prefix, "lruCacheSize"), defaultConfig.LruCacheSize, "Size of the AutoRefreshCache")
 	cmdFlags.Int(fmt.Sprintf("%v%v", prefix, "workers"), defaultConfig.Workers, "Number of parallel workers to refresh the cache")
+	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "defaultClusterLabel"), defaultConfig.DefaultClusterLabel, "The default cluster label. This will be used if label is not specified on the hive job.")
 	return cmdFlags
 }

--- a/go/tasks/plugins/hive/config/config_flags_test.go
+++ b/go/tasks/plugins/hive/config/config_flags_test.go
@@ -231,4 +231,26 @@ func TestConfig_SetFlags(t *testing.T) {
 			}
 		})
 	})
+	t.Run("Test_defaultClusterLabel", func(t *testing.T) {
+		t.Run("DefaultValue", func(t *testing.T) {
+			// Test that default value is set properly
+			if vString, err := cmdFlags.GetString("defaultClusterLabel"); err == nil {
+				assert.Equal(t, string(defaultConfig.DefaultClusterLabel), vString)
+			} else {
+				assert.FailNow(t, err.Error())
+			}
+		})
+
+		t.Run("Override", func(t *testing.T) {
+			testValue := "1"
+
+			cmdFlags.Set("defaultClusterLabel", testValue)
+			if vString, err := cmdFlags.GetString("defaultClusterLabel"); err == nil {
+				testDecodeJson_Config(t, fmt.Sprintf("%v", vString), &actual.DefaultClusterLabel)
+
+			} else {
+				assert.FailNow(t, err.Error())
+			}
+		})
+	})
 }


### PR DESCRIPTION
# TL;DR
Prior PR introduced this flag to allow DefaultClusterLabel to be configurable but it was not correctly worded.

## Type
 - [X] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [X] Code completed
 - [X] Smoke tested
 - [X] Unit tests added
 - [X] Code documentation added
 - [X] Any pending items have an associated Issue

## Tracking Issue
https://github.com/lyft/flyte/issues/307
