### PR TITLE
Mark Hive and Presto query failures as Retryable to allow Propeller to decide the behavior

### DIFF
--- a/go/tasks/plugins/hive/execution_state.go
+++ b/go/tasks/plugins/hive/execution_state.go
@@ -116,7 +116,7 @@ func MapExecutionStateToPhaseInfo(state ExecutionState, quboleClient client.Qubo
 		phaseInfo = core.PhaseInfoSuccess(ConstructTaskInfo(state))
 
 	case PhaseQueryFailed:
-		phaseInfo = core.PhaseInfoFailure(errors.DownstreamSystemError, "Query failed", ConstructTaskInfo(state))
+		phaseInfo = core.PhaseInfoRetryableFailure(errors.DownstreamSystemError, "Query failed", ConstructTaskInfo(state))
 	}
 
 	return phaseInfo

--- a/go/tasks/plugins/presto/execution_state.go
+++ b/go/tasks/plugins/presto/execution_state.go
@@ -495,7 +495,7 @@ func MapExecutionStateToPhaseInfo(state ExecutionState) core.PhaseInfo {
 			phaseInfo = core.PhaseInfoSuccess(ConstructTaskInfo(state))
 		}
 	case PhaseQueryFailed:
-		phaseInfo = core.PhaseInfoFailure(errors.DownstreamSystemError, "Query failed", ConstructTaskInfo(state))
+		phaseInfo = core.PhaseInfoRetryableFailure(errors.DownstreamSystemError, "Query failed", ConstructTaskInfo(state))
 	}
 
 	return phaseInfo


### PR DESCRIPTION
# TL;DR
Hive and Presto plugins report Permanent Failure when the query fails. This signals to Propeller that it should not retry the queries. Given that Hive & Presto do not report detailed failure reasons, it's not easy to figure out whether the query is in fact retryable or not. Returning Retryable all the time would at least enable Propeller to use user's retry strategy to resubmit these queries.

## Type
 - [X] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [X] Code completed
 - [X] Smoke tested
 - [X] Unit tests added
 - [X] Code documentation added
 - [X] Any pending items have an associated Issue

## Tracking Issue
https://github.com/lyft/flyte/issues/<number>
