### PR TITLE
Set the executor prod prefix in k8s

### DIFF
--- a/go/tasks/plugins/k8s/spark/spark.go
+++ b/go/tasks/plugins/k8s/spark/spark.go
@@ -149,6 +149,7 @@ func (sparkResourceHandler) BuildResource(ctx context.Context, taskCtx pluginsCo
 	if sparkConfig["spark.kubernetes.executor.limit.cores"] == "" && sparkConfig["spark.executor.cores"] != "" {
 		sparkConfig["spark.kubernetes.executor.limit.cores"] = sparkConfig["spark.executor.cores"]
 	}
+	sparkConfig["spark.kubernetes.executor.podNamePrefix"] = taskCtx.TaskExecutionMetadata().GetTaskExecutionID().GetGeneratedName()
 
 	j := &sparkOp.SparkApplication{
 		TypeMeta: metav1.TypeMeta{


### PR DESCRIPTION
Spark 2.4.6 changed the name of the executor pod name to not contain the execution id. This PR fixes the executor name to have the flyte execution id.