### PR TITLE
Presto - add option to use namespace as the user

### DIFF
--- a/go/tasks/plugins/presto/config/config.go
+++ b/go/tasks/plugins/presto/config/config.go
@@ -76,6 +76,7 @@ var (
 		Environment:         URLMustParse(""),
 		DefaultRoutingGroup: "adhoc",
 		DefaultUser:         "flyte-default-user",
+		UseNamespaceAsUser:  true,
 		RoutingGroupConfigs: []RoutingGroupConfig{{Name: "adhoc", Limit: 100}, {Name: "etl", Limit: 25}},
 		RefreshCacheConfig: RefreshCacheConfig{
 			Name:         "presto",
@@ -101,6 +102,7 @@ type Config struct {
 	Environment            config.URL           `json:"environment" pflag:",Environment endpoint for Presto to use"`
 	DefaultRoutingGroup    string               `json:"defaultRoutingGroup" pflag:",Default Presto routing group"`
 	DefaultUser            string               `json:"defaultUser" pflag:",Default Presto user"`
+	UseNamespaceAsUser     bool                 `json:"useNamespaceAsUser" pflag:",Use the K8s namespace as the user"`
 	RoutingGroupConfigs    []RoutingGroupConfig `json:"routingGroupConfigs" pflag:"-,A list of cluster configs. Each of the configs corresponds to a service cluster"`
 	RefreshCacheConfig     RefreshCacheConfig   `json:"refreshCacheConfig" pflag:"Refresh cache config"`
 	ReadRateLimiterConfig  RateLimiterConfig    `json:"readRateLimiterConfig" pflag:"Rate limiter config for read requests going to Presto"`

--- a/go/tasks/plugins/presto/config/config_flags.go
+++ b/go/tasks/plugins/presto/config/config_flags.go
@@ -44,6 +44,7 @@ func (cfg Config) GetPFlagSet(prefix string) *pflag.FlagSet {
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "environment"), defaultConfig.Environment.String(), "Environment endpoint for Presto to use")
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "defaultRoutingGroup"), defaultConfig.DefaultRoutingGroup, "Default Presto routing group")
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "defaultUser"), defaultConfig.DefaultUser, "Default Presto user")
+	cmdFlags.Bool(fmt.Sprintf("%v%v", prefix, "useNamespaceAsUser"), defaultConfig.UseNamespaceAsUser, "Use the K8s namespace as the user")
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "refreshCacheConfig.name"), defaultConfig.RefreshCacheConfig.Name, "The name of the rate limiter")
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "refreshCacheConfig.syncPeriod"), defaultConfig.RefreshCacheConfig.SyncPeriod.String(), "The duration to wait before the cache is refreshed again")
 	cmdFlags.Int(fmt.Sprintf("%v%v", prefix, "refreshCacheConfig.workers"), defaultConfig.RefreshCacheConfig.Workers, "Number of parallel workers to refresh the cache")

--- a/go/tasks/plugins/presto/config/config_flags_test.go
+++ b/go/tasks/plugins/presto/config/config_flags_test.go
@@ -165,6 +165,28 @@ func TestConfig_SetFlags(t *testing.T) {
 			}
 		})
 	})
+	t.Run("Test_useNamespaceAsUser", func(t *testing.T) {
+		t.Run("DefaultValue", func(t *testing.T) {
+			// Test that default value is set properly
+			if vBool, err := cmdFlags.GetBool("useNamespaceAsUser"); err == nil {
+				assert.Equal(t, bool(defaultConfig.UseNamespaceAsUser), vBool)
+			} else {
+				assert.FailNow(t, err.Error())
+			}
+		})
+
+		t.Run("Override", func(t *testing.T) {
+			testValue := "1"
+
+			cmdFlags.Set("useNamespaceAsUser", testValue)
+			if vBool, err := cmdFlags.GetBool("useNamespaceAsUser"); err == nil {
+				testDecodeJson_Config(t, fmt.Sprintf("%v", vBool), &actual.UseNamespaceAsUser)
+
+			} else {
+				assert.FailNow(t, err.Error())
+			}
+		})
+	})
 	t.Run("Test_refreshCacheConfig.name", func(t *testing.T) {
 		t.Run("DefaultValue", func(t *testing.T) {
 			// Test that default value is set properly


### PR DESCRIPTION
# TL;DR
In an effort to reduce the occurrence of the error in the issue, this makes the user that is sent when creating a Presto query the K8s namespace instead of the default username.

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [x] Code documentation added
 - [x] Any pending items have an associated Issue

## Complete description
This changes the user to be the K8s namespace.

## Tracking Issue
https://github.com/lyft/flyte/issues/348

## Follow-up issue
NA
