### PR TITLE
[Bug fix] SageMaker case sensitivity

### DIFF
--- a/go/tasks/plugins/k8s/sagemaker/utils.go
+++ b/go/tasks/plugins/k8s/sagemaker/utils.go
@@ -120,6 +120,7 @@ func buildParameterRanges(hpoJobConfig *sagemakerSpec.HyperparameterTuningJobCon
 	}
 
 	for prName, pr := range prMap {
+		scalingTypeString := strings.Title(strings.ToLower(pr.GetContinuousParameterRange().GetScalingType().String()))
 		switch pr.GetParameterRangeType().(type) {
 		case *sagemakerSpec.ParameterRangeOneOf_CategoricalParameterRange:
 			var newElem = commonv1.CategoricalParameterRange{
@@ -133,7 +134,7 @@ func buildParameterRanges(hpoJobConfig *sagemakerSpec.HyperparameterTuningJobCon
 				MaxValue:    awssagemaker.ToStringPtr(fmt.Sprintf("%f", pr.GetContinuousParameterRange().GetMaxValue())),
 				MinValue:    awssagemaker.ToStringPtr(fmt.Sprintf("%f", pr.GetContinuousParameterRange().GetMinValue())),
 				Name:        awssagemaker.ToStringPtr(prName),
-				ScalingType: commonv1.HyperParameterScalingType(pr.GetContinuousParameterRange().GetScalingType().String()),
+				ScalingType: commonv1.HyperParameterScalingType(scalingTypeString),
 			}
 			retValue.ContinuousParameterRanges = append(retValue.ContinuousParameterRanges, newElem)
 
@@ -142,7 +143,7 @@ func buildParameterRanges(hpoJobConfig *sagemakerSpec.HyperparameterTuningJobCon
 				MaxValue:    awssagemaker.ToStringPtr(fmt.Sprintf("%d", pr.GetIntegerParameterRange().GetMaxValue())),
 				MinValue:    awssagemaker.ToStringPtr(fmt.Sprintf("%d", pr.GetIntegerParameterRange().GetMinValue())),
 				Name:        awssagemaker.ToStringPtr(prName),
-				ScalingType: commonv1.HyperParameterScalingType(pr.GetContinuousParameterRange().GetScalingType().String()),
+				ScalingType: commonv1.HyperParameterScalingType(scalingTypeString),
 			}
 			retValue.IntegerParameterRanges = append(retValue.IntegerParameterRanges, newElem)
 		}


### PR DESCRIPTION
# TL;DR
A lot of the fields in SageMaker CRDs are case sensitive, but only some of them are validated at CRD level. The bug this PR fixed was detected by the operator.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
A lot of the fields in SageMaker CRDs are case sensitive, but only some of them are validated at CRD level. The bug this PR fixed was detected by the operator. We use `strings.Title(strings.ToLower(<protoc enum>.String()))` to fix it.

## Tracking Issue


## Follow-up issue
_NA_

