### PR TITLE
Raw output prefix

### DIFF
--- a/go/tasks/pluginmachinery/flytek8s/pod_helper_test.go
+++ b/go/tasks/pluginmachinery/flytek8s/pod_helper_test.go
@@ -91,6 +91,7 @@ func TestToK8sPodIterruptible(t *testing.T) {
 
 	op := &pluginsIOMock.OutputFilePaths{}
 	op.On("GetOutputPrefixPath").Return(storage.DataReference(""))
+	op.On("GetRawOutputPrefix").Return(storage.DataReference(""))
 
 	x := dummyTaskExecutionMetadata(&v1.ResourceRequirements{
 		Limits: v1.ResourceList{
@@ -139,6 +140,7 @@ func TestToK8sPod(t *testing.T) {
 
 	op := &pluginsIOMock.OutputFilePaths{}
 	op.On("GetOutputPrefixPath").Return(storage.DataReference(""))
+	op.On("GetRawOutputPrefix").Return(storage.DataReference(""))
 
 	t.Run("WithGPU", func(t *testing.T) {
 		x := dummyTaskExecutionMetadata(&v1.ResourceRequirements{

--- a/go/tasks/pluginmachinery/utils/template.go
+++ b/go/tasks/pluginmachinery/utils/template.go
@@ -19,6 +19,7 @@ var inputFileRegex = regexp.MustCompile(`(?i){{\s*[\.$]Input\s*}}`)
 var inputPrefixRegex = regexp.MustCompile(`(?i){{\s*[\.$]InputPrefix\s*}}`)
 var outputRegex = regexp.MustCompile(`(?i){{\s*[\.$]OutputPrefix\s*}}`)
 var inputVarRegex = regexp.MustCompile(`(?i){{\s*[\.$]Inputs\.(?P<input_name>[^}\s]+)\s*}}`)
+var rawOutputDataPrefixRegex = regexp.MustCompile(`(?i){{\s*[\.$]RawOutputDataPrefix\s*}}`)
 
 // Evaluates templates in each command with the equivalent value from passed args. Templates are case-insensitive
 // Supported templates are:
@@ -68,6 +69,7 @@ func replaceTemplateCommandArgs(ctx context.Context, commandTemplate string, in 
 	val := inputFileRegex.ReplaceAllString(commandTemplate, in.GetInputPath().String())
 	val = outputRegex.ReplaceAllString(val, out.GetOutputPrefixPath().String())
 	val = inputPrefixRegex.ReplaceAllString(val, in.GetInputPrefixPath().String())
+	val = rawOutputDataPrefixRegex.ReplaceAllString(val, out.GetRawOutputPrefix().String())
 
 	inputs, err := in.Get(ctx)
 	if err != nil {

--- a/go/tasks/pluginmachinery/utils/template_test.go
+++ b/go/tasks/pluginmachinery/utils/template_test.go
@@ -182,6 +182,7 @@ func TestReplaceTemplateCommandArgs(t *testing.T) {
 			"world",
 			"${{input}}",
 			"{{ .OutputPrefix }}",
+			"--switch {{ .rawOutputDataPrefix }}",
 		}, in, out)
 		assert.NoError(t, err)
 		assert.Equal(t, []string{
@@ -189,6 +190,7 @@ func TestReplaceTemplateCommandArgs(t *testing.T) {
 			"world",
 			"${{input}}",
 			"output/blah",
+			"--switch s3://custom-bucket",
 		}, actual)
 	})
 
@@ -209,6 +211,7 @@ func TestReplaceTemplateCommandArgs(t *testing.T) {
 			"world",
 			`--someArg {{ .Inputs.arr }}`,
 			"{{ .OutputPrefix }}",
+			"{{ $RawOutputDataPrefix }}",
 		}, in, out)
 		assert.NoError(t, err)
 		assert.Equal(t, []string{
@@ -216,6 +219,7 @@ func TestReplaceTemplateCommandArgs(t *testing.T) {
 			"world",
 			"--someArg [a,b]",
 			"output/blah",
+			"s3://custom-bucket",
 		}, actual)
 	})
 
@@ -230,6 +234,7 @@ func TestReplaceTemplateCommandArgs(t *testing.T) {
 			"world",
 			`--someArg {{ .Inputs.date }}`,
 			"{{ .OutputPrefix }}",
+			"{{ .rawOutputDataPrefix }}",
 		}, in, out)
 		assert.NoError(t, err)
 		assert.Equal(t, []string{
@@ -237,6 +242,7 @@ func TestReplaceTemplateCommandArgs(t *testing.T) {
 			"world",
 			"--someArg 1900-01-01T01:01:01.000000001Z",
 			"output/blah",
+			"s3://custom-bucket",
 		}, actual)
 	})
 
@@ -251,6 +257,7 @@ func TestReplaceTemplateCommandArgs(t *testing.T) {
 			"world",
 			`--someArg {{ .Inputs.arr }}`,
 			"{{ .OutputPrefix }}",
+			"{{ .wrongOutputDataPrefix }}",
 		}, in, out)
 		assert.NoError(t, err)
 		assert.Equal(t, []string{
@@ -258,6 +265,7 @@ func TestReplaceTemplateCommandArgs(t *testing.T) {
 			"world",
 			"--someArg [[a,b],[1,2]]",
 			"output/blah",
+			"{{ .wrongOutputDataPrefix }}",
 		}, actual)
 	})
 
@@ -269,6 +277,7 @@ func TestReplaceTemplateCommandArgs(t *testing.T) {
 			"world",
 			`--someArg {{ .Inputs.arr }}`,
 			"{{ .OutputPrefix }}",
+			"--raw-data-output-prefix {{ .rawOutputDataPrefix }}",
 		}, in, out)
 		assert.NoError(t, err)
 		assert.Equal(t, []string{
@@ -276,6 +285,7 @@ func TestReplaceTemplateCommandArgs(t *testing.T) {
 			"world",
 			`--someArg {{ .Inputs.arr }}`,
 			"output/blah",
+			"--raw-data-output-prefix s3://custom-bucket",
 		}, actual)
 	})
 

--- a/go/tasks/plugins/array/awsbatch/launcher_test.go
+++ b/go/tasks/plugins/array/awsbatch/launcher_test.go
@@ -78,6 +78,7 @@ func TestLaunchSubTasks(t *testing.T) {
 
 	ow := &mocks3.OutputWriter{}
 	ow.OnGetOutputPrefixPath().Return("/prefix/")
+	ow.OnGetRawOutputPrefix().Return("s3://")
 
 	ir := &mocks3.InputReader{}
 	ir.OnGetInputPrefixPath().Return("/prefix/")

--- a/go/tasks/plugins/array/awsbatch/transformer_test.go
+++ b/go/tasks/plugins/array/awsbatch/transformer_test.go
@@ -172,6 +172,7 @@ func TestArrayJobToBatchInput(t *testing.T) {
 
 	or := &mocks2.OutputWriter{}
 	or.OnGetOutputPrefixPath().Return("/path/output")
+	or.OnGetRawOutputPrefix().Return("s3://")
 
 	taskCtx := &mocks.TaskExecutionContext{}
 	taskCtx.OnTaskExecutionMetadata().Return(tMetadata)

--- a/go/tasks/plugins/k8s/container/container_test.go
+++ b/go/tasks/plugins/k8s/container/container_test.go
@@ -86,6 +86,7 @@ func dummyContainerTaskContext(resources *v1.ResourceRequirements, command []str
 	outputReader := &pluginsIOMock.OutputWriter{}
 	outputReader.On("GetOutputPath").Return(storage.DataReference("/data/outputs.pb"))
 	outputReader.On("GetOutputPrefixPath").Return(storage.DataReference("/data/"))
+	outputReader.On("GetRawOutputPrefix").Return(storage.DataReference(""))
 	taskCtx.On("OutputWriter").Return(outputReader)
 
 	taskReader := &pluginsCoreMock.TaskReader{}

--- a/go/tasks/plugins/k8s/kfoperators/pytorch/pytorch_test.go
+++ b/go/tasks/plugins/k8s/kfoperators/pytorch/pytorch_test.go
@@ -107,6 +107,7 @@ func dummyPytorchTaskContext(taskTemplate *core.TaskTemplate) pluginsCore.TaskEx
 	outputReader := &pluginIOMocks.OutputWriter{}
 	outputReader.OnGetOutputPath().Return(storage.DataReference("/data/outputs.pb"))
 	outputReader.OnGetOutputPrefixPath().Return(storage.DataReference("/data/"))
+	outputReader.OnGetRawOutputPrefix().Return(storage.DataReference(""))
 	taskCtx.OnOutputWriter().Return(outputReader)
 
 	taskReader := &mocks.TaskReader{}

--- a/go/tasks/plugins/k8s/sagemaker/config/config_flags.go
+++ b/go/tasks/plugins/k8s/sagemaker/config/config_flags.go
@@ -43,5 +43,6 @@ func (cfg Config) GetPFlagSet(prefix string) *pflag.FlagSet {
 	cmdFlags := pflag.NewFlagSet("Config", pflag.ExitOnError)
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "roleArn"), defaultConfig.RoleArn, "The role the SageMaker plugin uses to communicate with the SageMaker service")
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "region"), defaultConfig.Region, "The AWS region the SageMaker plugin communicates to")
+	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "roleAnnotationKey"), defaultConfig.RoleAnnotationKey, "Map key to use to lookup role from task annotations.")
 	return cmdFlags
 }

--- a/go/tasks/plugins/k8s/sagemaker/config/config_flags_test.go
+++ b/go/tasks/plugins/k8s/sagemaker/config/config_flags_test.go
@@ -143,4 +143,26 @@ func TestConfig_SetFlags(t *testing.T) {
 			}
 		})
 	})
+	t.Run("Test_roleAnnotationKey", func(t *testing.T) {
+		t.Run("DefaultValue", func(t *testing.T) {
+			// Test that default value is set properly
+			if vString, err := cmdFlags.GetString("roleAnnotationKey"); err == nil {
+				assert.Equal(t, string(defaultConfig.RoleAnnotationKey), vString)
+			} else {
+				assert.FailNow(t, err.Error())
+			}
+		})
+
+		t.Run("Override", func(t *testing.T) {
+			testValue := "1"
+
+			cmdFlags.Set("roleAnnotationKey", testValue)
+			if vString, err := cmdFlags.GetString("roleAnnotationKey"); err == nil {
+				testDecodeJson_Config(t, fmt.Sprintf("%v", vString), &actual.RoleAnnotationKey)
+
+			} else {
+				assert.FailNow(t, err.Error())
+			}
+		})
+	})
 }

--- a/go/tasks/plugins/k8s/sidecar/sidecar_test.go
+++ b/go/tasks/plugins/k8s/sidecar/sidecar_test.go
@@ -103,6 +103,7 @@ func getDummySidecarTaskContext(taskTemplate *core.TaskTemplate, resources *v1.R
 	outputReader := &pluginsIOMock.OutputWriter{}
 	outputReader.On("GetOutputPath").Return(storage.DataReference("/data/outputs.pb"))
 	outputReader.On("GetOutputPrefixPath").Return(storage.DataReference("/data/"))
+	outputReader.On("GetRawOutputPrefix").Return(storage.DataReference(""))
 	taskCtx.On("OutputWriter").Return(outputReader)
 
 	taskReader := &pluginsCoreMock.TaskReader{}

--- a/go/tasks/plugins/k8s/spark/spark_test.go
+++ b/go/tasks/plugins/k8s/spark/spark_test.go
@@ -231,6 +231,8 @@ func dummySparkTaskContext(taskTemplate *core.TaskTemplate) pluginsCore.TaskExec
 	outputReader := &pluginIOMocks.OutputWriter{}
 	outputReader.On("GetOutputPath").Return(storage.DataReference("/data/outputs.pb"))
 	outputReader.On("GetOutputPrefixPath").Return(storage.DataReference("/data/"))
+	outputReader.On("GetRawOutputPrefix").Return(storage.DataReference(""))
+
 	taskCtx.On("OutputWriter").Return(outputReader)
 
 	taskReader := &mocks.TaskReader{}

--- a/go/tasks/plugins/presto/helpers_test.go
+++ b/go/tasks/plugins/presto/helpers_test.go
@@ -95,6 +95,7 @@ func GetMockTaskExecutionContext() core.TaskExecutionContext {
 	outputReader := &ioMock.OutputWriter{}
 	outputReader.On("GetOutputPath").Return(storage.DataReference("/data/outputs.pb"))
 	outputReader.On("GetOutputPrefixPath").Return(storage.DataReference("/data/"))
+	outputReader.On("GetRawOutputPrefix").Return(storage.DataReference("s3://"))
 	taskCtx.On("OutputWriter").Return(outputReader)
 
 	taskReader := &coreMock.TaskReader{}


### PR DESCRIPTION
# TL;DR
This will pipe through the raw output data prefix, as set by the [flytekit PR](https://github.com/lyft/flytekit/pull/146/files#diff-937f5bf70e8c655b5e2731a288bc3db8R17), through admin/propeller/propeller's node execution context, to container based plugins that call the replaceTemplateArgs.

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
* Add regex, use regex to fill in the container args.
* Also accidentally ran `make generate` so some stuff got updated.

## Tracking Issue
https://github.com/lyft/flyte/issues/211

## Follow-up issue
NA
