### PR TITLE
feat; allow users choose raw output path style (sharded, non sharded, human readable etc)

### DIFF
--- a/go/tasks/pluginmachinery/ioutils/raw_output_path.go
+++ b/go/tasks/pluginmachinery/ioutils/raw_output_path.go
@@ -44,8 +44,8 @@ func NewShardedDeterministicRawOutputPath(ctx context.Context, sharder ShardSele
 }
 
 // A simple Output sandbox at a given path
-func NewRawOutputPaths(_ context.Context, outputSandboxPath storage.DataReference) io.RawOutputPaths {
-	return precomputedRawOutputPaths{path: outputSandboxPath}
+func NewRawOutputPaths(_ context.Context, rawOutputPrefix storage.DataReference) io.RawOutputPaths {
+	return precomputedRawOutputPaths{path: rawOutputPrefix}
 }
 
 // Creates an OutputSandbox in the basePath using the uniqueID and a sharder
@@ -57,6 +57,24 @@ func NewShardedRawOutputPath(ctx context.Context, sharder ShardSelector, basePat
 		return nil, err
 	}
 	path, err := store.ConstructReference(ctx, basePath, prefix, uniqueID)
+	if err != nil {
+		return nil, err
+	}
+	return precomputedRawOutputPaths{
+		path: path,
+	}, nil
+}
+
+// Constructs an output path that is deterministic and unique within the given outputPrefix. No sharding is performed
+func NewDeterministicUniqueRawOutputPath(ctx context.Context, rawOutputPrefix, outputMetadataPrefix storage.DataReference, store storage.ReferenceConstructor) (io.RawOutputPaths, error) {
+	o := []byte(outputMetadataPrefix)
+	/* #nosec */
+	// We use SHA1 for sheer speed instead of no collisions. As because of the shard Prefix + hash is pretty unique :)
+	m := sha1.New()
+	if _, err := m.Write(o); err != nil {
+		return nil, err
+	}
+	path, err := store.ConstructReference(ctx, rawOutputPrefix, hex.EncodeToString(m.Sum(nil)))
 	if err != nil {
 		return nil, err
 	}

--- a/go/tasks/pluginmachinery/ioutils/raw_output_path_test.go
+++ b/go/tasks/pluginmachinery/ioutils/raw_output_path_test.go
@@ -68,8 +68,8 @@ func TestNewTaskIDRawOutputPath(t *testing.T) {
 			NodeId: "n1",
 			ExecutionId: &core2.WorkflowExecutionIdentifier{
 				Project: "project",
-				Domain: "domain",
-				Name: "exec",
+				Domain:  "domain",
+				Name:    "exec",
 			},
 		},
 		RetryAttempt: 0,

--- a/go/tasks/pluginmachinery/ioutils/raw_output_path_test.go
+++ b/go/tasks/pluginmachinery/ioutils/raw_output_path_test.go
@@ -12,7 +12,7 @@ func TestNewOutputSandbox(t *testing.T) {
 	assert.Equal(t, NewRawOutputPaths(context.TODO(), "x").GetRawOutputPrefix(), storage.DataReference("x"))
 }
 
-func TestNewRandomPrefixShardedOutputSandbox(t *testing.T) {
+func TestNewShardedDeterministicRawOutputPath(t *testing.T) {
 	ctx := context.TODO()
 
 	t.Run("success-path", func(t *testing.T) {
@@ -29,7 +29,7 @@ func TestNewRandomPrefixShardedOutputSandbox(t *testing.T) {
 	})
 }
 
-func TestNewShardedOutputSandbox(t *testing.T) {
+func TestNewShardedRawOutputPath(t *testing.T) {
 	ctx := context.TODO()
 	t.Run("", func(t *testing.T) {
 		ss := NewConstantShardSelector([]string{"x"})
@@ -42,5 +42,21 @@ func TestNewShardedOutputSandbox(t *testing.T) {
 		ss := NewConstantShardSelector([]string{"s3:// abc"})
 		sd, err := NewShardedRawOutputPath(ctx, ss, "s3://bucket", "m", storage.URLPathConstructor{})
 		assert.Error(t, err, "%s", sd)
+	})
+}
+
+func TestNewDeterministicUniqueRawOutputPath(t *testing.T) {
+	ctx := context.TODO()
+
+	t.Run("success-path", func(t *testing.T) {
+		sd, err := NewDeterministicUniqueRawOutputPath(ctx, "s3://bucket", "m", storage.URLPathConstructor{})
+		assert.NoError(t, err)
+		assert.Equal(t, storage.DataReference("s3://bucket/6b0d31c0d563223024da45691584643ac78c96e8"), sd.GetRawOutputPrefix())
+	})
+
+	t.Run("error-not-possible", func(t *testing.T) {
+		sd, err := NewDeterministicUniqueRawOutputPath(ctx, "bucket", "m", storage.URLPathConstructor{})
+		assert.NoError(t, err)
+		assert.Equal(t, "/bucket/6b0d31c0d563223024da45691584643ac78c96e8", sd.GetRawOutputPrefix().String())
 	})
 }

--- a/go/tasks/pluginmachinery/ioutils/raw_output_path_test.go
+++ b/go/tasks/pluginmachinery/ioutils/raw_output_path_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	core2 "github.com/lyft/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/lyft/flytestdlib/storage"
 	"github.com/stretchr/testify/assert"
 )
@@ -59,4 +60,23 @@ func TestNewDeterministicUniqueRawOutputPath(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, "/bucket/6b0d31c0d563223024da45691584643ac78c96e8", sd.GetRawOutputPrefix().String())
 	})
+}
+
+func TestNewTaskIDRawOutputPath(t *testing.T) {
+	p, err := NewTaskIDRawOutputPath(context.TODO(), "s3://bucket", &core2.TaskExecutionIdentifier{
+		NodeExecutionId: &core2.NodeExecutionIdentifier{
+			NodeId: "n1",
+			ExecutionId: &core2.WorkflowExecutionIdentifier{
+				Project: "project",
+				Domain: "domain",
+				Name: "exec",
+			},
+		},
+		RetryAttempt: 0,
+		TaskId: &core2.Identifier{
+			Name: "task1",
+		},
+	}, storage.URLPathConstructor{})
+	assert.NoError(t, err)
+	assert.Equal(t, "s3://bucket/project/domain/exec/n1/0/task1", p.GetRawOutputPrefix().String())
 }


### PR DESCRIPTION
# TL;DR
Currently we store data in 2 char shards always. This is useful only at the root of a pre-sharded S3 bucket. This change makes it possible to not have to use the 2 char shard, but Flyte will automatically generate a shard in your bucket where to write the data

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [x] Unit tests added
 - [x] Code documentation added
 - [ x Any pending items have an associated Issue

## Complete description
This will enable capability to not create shard chars when not required.
 - Prefix sharding is only useful for S3 and specifically for
   provisioned buckets
 - For buckets that are not provisioned for high throughput, it might be
   useful to use no sharding to make it easy to find the path
 - The path option is still not human readable but derivable

## Tracking Issue
https://github.com/lyft/flyte/issues/486

## Follow-up issue
_NA_

