### PR TITLE
Use flyte configuration defaults for sidecar pod spec

### DIFF
--- a/boilerplate/lyft/golang_support_tools/tools.go
+++ b/boilerplate/lyft/golang_support_tools/tools.go
@@ -3,8 +3,8 @@
 package tools
 
 import (
+	_ "github.com/alvaroloes/enumer"
 	_ "github.com/golangci/golangci-lint/cmd/golangci-lint"
 	_ "github.com/lyft/flytestdlib/cli/pflags"
 	_ "github.com/vektra/mockery/cmd/mockery"
-	_ "github.com/alvaroloes/enumer"
 )

--- a/copilot/data/download.go
+++ b/copilot/data/download.go
@@ -25,7 +25,7 @@ import (
 
 type Downloader struct {
 	format core.DataLoadingConfig_LiteralMapFormat
-	store *storage.DataStore
+	store  *storage.DataStore
 	// TODO support download mode
 	mode core.IOStrategy_DownloadMode
 }

--- a/copilot/data/upload.go
+++ b/copilot/data/upload.go
@@ -12,9 +12,9 @@ import (
 
 	"github.com/golang/protobuf/proto"
 	"github.com/lyft/flyteidl/gen/pb-go/flyteidl/core"
+	"github.com/lyft/flytestdlib/futures"
 	"github.com/lyft/flytestdlib/logger"
 	"github.com/lyft/flytestdlib/storage"
-	"github.com/lyft/flytestdlib/futures"
 	"github.com/pkg/errors"
 
 	"github.com/lyft/flyteplugins/go/tasks/pluginmachinery/utils"

--- a/go.mod
+++ b/go.mod
@@ -8,11 +8,11 @@ require (
 	github.com/aws/amazon-sagemaker-operator-for-k8s v1.0.1-0.20200410212604-780c48ecb21a
 	github.com/aws/aws-sdk-go v1.29.23
 	github.com/coocood/freecache v1.1.0
+	github.com/evanphx/json-patch v4.5.0+incompatible
 	github.com/fsnotify/fsnotify v1.4.9
 	github.com/go-test/deep v1.0.5
 	github.com/gogo/protobuf v1.3.1
 	github.com/golang/protobuf v1.3.5
-	github.com/googleapis/gnostic v0.4.1 // indirect
 	github.com/hashicorp/golang-lru v0.5.4
 	github.com/kubeflow/pytorch-operator v0.6.0
 	github.com/kubeflow/tf-operator v0.5.3
@@ -27,19 +27,16 @@ require (
 	github.com/spf13/cobra v0.0.6
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.6.1
-	go.opencensus.io v0.22.3 // indirect
 	golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e
 	golang.org/x/tools v0.0.0-20200304193943-95d2e580d8eb
 	google.golang.org/grpc v1.28.0
 	gopkg.in/yaml.v2 v2.2.8
-	gopkg.in/yaml.v3 v3.0.0-20200605160147-a5ece683394c // indirect
 	gotest.tools v2.2.0+incompatible
 	k8s.io/api v0.17.3
 	k8s.io/apimachinery v0.17.3
 	k8s.io/client-go v11.0.1-0.20190918222721-c0e3722d5cf0+incompatible
 	k8s.io/klog v1.0.0
 	sigs.k8s.io/controller-runtime v0.5.1
-	sigs.k8s.io/yaml v1.2.0 // indirect
 )
 
 // Pin the version of client-go to something that's compatible with katrogan's fork of api and apimachinery

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/aws/amazon-sagemaker-operator-for-k8s v1.0.1-0.20200410212604-780c48ecb21a
 	github.com/aws/aws-sdk-go v1.29.23
 	github.com/coocood/freecache v1.1.0
-	github.com/evanphx/json-patch v4.5.0+incompatible
 	github.com/fsnotify/fsnotify v1.4.9
 	github.com/go-test/deep v1.0.5
 	github.com/gogo/protobuf v1.3.1

--- a/go/tasks/pluginmachinery/flytek8s/testdata/config.yaml
+++ b/go/tasks/pluginmachinery/flytek8s/testdata/config.yaml
@@ -5,6 +5,7 @@ plugins:
     - container
   # All k8s plugins default configuration
   k8s:
+    scheduler-name: flyte-scheduler
     default-annotations:
       - annotationKey1: annotationValue1
       - annotationKey2: annotationValue2
@@ -12,11 +13,6 @@ plugins:
       - label1: labelValue1
       - label2: labelValue2
     resource-tolerations:
-      nvidia.com/gpu:
-        key: flyte/gpu
-        value: dedicated
-        operator: Equal
-        effect: NoSchedule
       storage:
         - key: storage
           value: special

--- a/go/tasks/pluginmachinery/flytek8s/testdata/config.yaml
+++ b/go/tasks/pluginmachinery/flytek8s/testdata/config.yaml
@@ -13,6 +13,11 @@ plugins:
       - label1: labelValue1
       - label2: labelValue2
     resource-tolerations:
+      nvidia.com/gpu:
+        key: flyte/gpu
+        value: dedicated
+        operator: Equal
+        effect: NoSchedule
       storage:
         - key: storage
           value: special

--- a/go/tasks/plugins/k8s/sidecar/sidecar_test.go
+++ b/go/tasks/plugins/k8s/sidecar/sidecar_test.go
@@ -114,56 +114,6 @@ func getDummySidecarTaskContext(taskTemplate *core.TaskTemplate, resources *v1.R
 	return taskCtx
 }
 
-func TestMergePodSpecs(t *testing.T) {
-	flyteConfiguredPodSpec := &v1.PodSpec{
-		RestartPolicy: v1.RestartPolicyNever,
-		Tolerations: []v1.Toleration{
-			{
-				Key:      "flyte/gpu",
-				Value:    "dedicated",
-				Operator: v1.TolerationOpEqual,
-				Effect:   v1.TaintEffectNoSchedule,
-			},
-		},
-		ServiceAccountName: "serviceaccountname",
-		SchedulerName:      "schedulername",
-		NodeSelector: map[string]string{
-			"flyte": "configured",
-		},
-	}
-	sidecarPodSpec := &v1.PodSpec{
-		Tolerations: []v1.Toleration{
-			{
-				Key:   "my toleration key",
-				Value: "my toleration value",
-			},
-		},
-		NodeSelector: map[string]string{
-			"user": "also configured",
-		},
-	}
-	mergePodSpecs(flyteConfiguredPodSpec, sidecarPodSpec)
-	assert.Equal(t, v1.RestartPolicyNever, sidecarPodSpec.RestartPolicy)
-	for _, tol := range sidecarPodSpec.Tolerations {
-		if tol.Key == "flyte/gpu" {
-			assert.Equal(t, tol.Value, "dedicated")
-			assert.Equal(t, tol.Operator, v1.TolerationOperator("Equal"))
-			assert.Equal(t, tol.Effect, v1.TaintEffect("NoSchedule"))
-		} else if tol.Key == "my toleration key" {
-			assert.Equal(t, tol.Value, "my toleration value")
-		} else {
-			t.Fatalf("unexpected toleration [%+v]", tol)
-		}
-	}
-	assert.Equal(t, "serviceaccountname", sidecarPodSpec.ServiceAccountName)
-	assert.Equal(t, "schedulername", sidecarPodSpec.SchedulerName)
-	assert.Len(t, sidecarPodSpec.Tolerations, 2)
-	assert.EqualValues(t, map[string]string{
-		"flyte": "configured",
-		"user":  "also configured",
-	}, sidecarPodSpec.NodeSelector)
-}
-
 func TestBuildSidecarResource(t *testing.T) {
 	dir, err := os.Getwd()
 	if err != nil {


### PR DESCRIPTION
# TL;DR
Use flyte configuration defaults for sidecar pod spec.

I tried to be clever and use a patch strategy that doesn't require hand curation for every additional field we write a default for, but I was unsuccessful. I tried dumping pod specs to json and using a merge patch that way but it failed for list fields :( 

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
User reported (thank you @jeevb)


## Tracking Issue
https://github.com/lyft/flyte/issues/548

## Follow-up issue
_NA_
