### PR TITLE
Update Spark Plugin

### DIFF
--- a/go/tasks/plugins/k8s/spark/spark_test.go
+++ b/go/tasks/plugins/k8s/spark/spark_test.go
@@ -3,6 +3,7 @@ package spark
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"testing"
 
 	"github.com/lyft/flyteplugins/go/tasks/pluginmachinery/flytek8s/config"
@@ -37,9 +38,9 @@ const sparkUIAddress = "spark-ui.flyte"
 
 var (
 	dummySparkConf = map[string]string{
-		"spark.driver.memory":          "500M",
+		"spark.driver.memory":          "200M",
 		"spark.driver.cores":           "1",
-		"spark.executor.cores":         "1",
+		"spark.executor.cores":         "2",
 		"spark.executor.instances":     "3",
 		"spark.executor.memory":        "500M",
 		"spark.flyte.feature1.enabled": "true",
@@ -316,6 +317,19 @@ func TestBuildResourceSpark(t *testing.T) {
 	assert.Equal(t, sj.PythonApplicationType, sparkApp.Spec.Type)
 	assert.Equal(t, testArgs, sparkApp.Spec.Arguments)
 	assert.Equal(t, testImage, *sparkApp.Spec.Image)
+
+	//Validate Driver/Executor Spec.
+
+	driverCores, _ := strconv.Atoi(dummySparkConf["spark.driver.cores"])
+	execCores, _ := strconv.Atoi(dummySparkConf["spark.executor.cores"])
+	execInstances, _ := strconv.Atoi(dummySparkConf["spark.executor.instances"])
+
+	assert.Equal(t, int32(driverCores), *sparkApp.Spec.Driver.Cores)
+	assert.Equal(t, int32(execCores), *sparkApp.Spec.Executor.Cores)
+	assert.Equal(t, int32(execInstances), *sparkApp.Spec.Executor.Instances)
+	assert.Equal(t, dummySparkConf["spark.driver.memory"], *sparkApp.Spec.Driver.Memory)
+	assert.Equal(t, dummySparkConf["spark.executor.memory"], *sparkApp.Spec.Executor.Memory)
+
 	// Validate Interruptible Toleration and NodeSelector set for Executor but not Driver.
 	assert.Equal(t, 0, len(sparkApp.Spec.Driver.Tolerations))
 	assert.Equal(t, 0, len(sparkApp.Spec.Driver.NodeSelector))


### PR DESCRIPTION
# TL;DR
SparkOperator v1beta2 expects Driver/Executor cores in the CRD else it defaults these values if they are not set which then takes precedence over spark_conf values effectively leading to no way of specifying these as part of spark_conf. This looks like an un-intended behavior in the operator but for now, let's add these values at both places to be safe. 

Ref: https://github.com/lyft/flyte/issues/585

Filed an Operator issue in https://github.com/GoogleCloudPlatform/spark-on-k8s-operator/issues/1055 

## Type
 - [ ] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/lyft/flyte/issues/585
## Follow-up issue
_NA_
OR
_https://github.com/lyft/flyte/issues/<number>_
